### PR TITLE
Fix content description for upvotes

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/VoteHelpers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/VoteHelpers.kt
@@ -29,10 +29,10 @@ fun VoteGeneric(
             if (myVote == 1) {
                 stringResource(R.string.upvoted)
             } else {
-                stringResource(R.string.downvoted)
+                stringResource(R.string.upvote)
             }
         } else {
-            if (myVote == 1) {
+            if (myVote == -1) {
                 stringResource(R.string.downvoted)
             } else {
                 stringResource(R.string.downvote)


### PR DESCRIPTION
For #1514

> The upvote buttons are read as ‘downvoted’.

I had noticed this before but I had fixed it wrongly. 

