### PR TITLE
chore(deps): update kotlin monorepo to v2 (major)

### DIFF
--- a/app/benchmark-rules.pro
+++ b/app/benchmark-rules.pro
@@ -4,3 +4,4 @@
 # wrong symbols would be generated. The generated Baseline Profile will be properly applied when generated
 # without obfuscation and your app is being obfuscated.
 -dontobfuscate
+-dontwarn org.slf4j.impl.StaticLoggerBinder

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("com.google.devtools.ksp")
     id("androidx.baselineprofile")
-    kotlin("plugin.serialization") version "1.9.24"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
+    kotlin("plugin.serialization") version "2.0.0"
 
 }
 
@@ -101,9 +102,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("com.android.application") version "8.4.1" apply false
     id("com.android.library") version "8.4.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
     id("org.jmailen.kotlinter") version "4.3.0" apply false
-    id("com.google.devtools.ksp") version "1.9.24-1.0.20" apply false
+    id("com.google.devtools.ksp") version "2.0.0-1.0.21" apply false
     id("com.android.test") version "8.4.1" apply false
     id("androidx.baselineprofile") version "1.2.4" apply false
 }


### PR DESCRIPTION
The 2.0.0 kotlin compiler has been released already. It just moved now to a plugin

https://developer.android.com/jetpack/androidx/releases/compose-kotlin