### PR TITLE
Refactor deprecated M1 SwipeToDismiss, use M3 SwipeToDismissBox

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,12 +132,6 @@ dependencies {
     implementation("io.noties.markwon:image-coil:4.6.2")
     implementation("io.noties.markwon:linkify:4.6.2")
 
-    // Accompanist
-    implementation("com.google.accompanist:accompanist-pager:0.34.0")
-    implementation("com.google.accompanist:accompanist-pager-indicators:0.34.0")
-    implementation("com.google.accompanist:accompanist-flowlayout:0.34.0")
-    implementation("com.google.accompanist:accompanist-navigation-animation:0.34.0")
-
     // LiveData
     implementation("androidx.compose.runtime:runtime-livedata")
     implementation("androidx.lifecycle:lifecycle-runtime-compose")
@@ -184,7 +178,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
 
     implementation("org.ocpsoft.prettytime:prettytime:5.0.8.Final")
-    implementation("androidx.navigation:navigation-compose")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -492,7 +492,7 @@ class MainActivity : AppCompatActivity() {
                         val args = Route.PostArgs(it)
 
                         SwipeToNavigateBack(
-                            appSettings.postNavigationGestureMode,
+                            appSettings.postNavigationGestureMode.toEnumSafe(),
                             appState::navigateUp,
                         ) {
                             PostActivity(

--- a/app/src/main/java/com/jerboa/feat/PostNavigationGestureMode.kt
+++ b/app/src/main/java/com/jerboa/feat/PostNavigationGestureMode.kt
@@ -12,7 +12,7 @@ enum class PostNavigationGestureMode(
     Disabled(R.string.look_and_feel_post_navigation_gesture_mode_disabled),
 
     /**
-     * Enable swiping left to navigate away from a post.
+     * Enable swiping right to navigate away from a post.
      */
-    SwipeLeft(R.string.look_and_feel_post_navigation_gesture_mode_swipe_left),
+    SwipeRight(R.string.look_and_feel_post_navigation_gesture_mode_swipe_right),
 }

--- a/app/src/main/java/com/jerboa/ui/components/common/SwipeToAction.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/SwipeToAction.kt
@@ -141,7 +141,6 @@ fun SwipeToAction(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberSwipeActionState(
     swipeToActionPreset: SwipeToActionPreset,

--- a/app/src/main/java/com/jerboa/ui/components/common/SwipeToNavigateBack.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/SwipeToNavigateBack.kt
@@ -3,56 +3,46 @@ package com.jerboa.ui.components.common
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.DismissDirection
-import androidx.compose.material.DismissValue
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.FractionalThreshold
-import androidx.compose.material.SwipeToDismiss
-import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.jerboa.feat.PostNavigationGestureMode
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun SwipeToNavigateBack(
-    useSwipeBack: Int,
+    useSwipeBack: PostNavigationGestureMode,
     onSwipeBack: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    if (useSwipeBack == PostNavigationGestureMode.SwipeLeft.ordinal) {
-        val dismissState =
-            rememberDismissState(
-                confirmStateChange = {
+    if (useSwipeBack == PostNavigationGestureMode.SwipeRight) {
+        SwipeToDismissBox(
+            state = rememberSwipeToDismissBoxState(
+                confirmValueChange = {
                     when (it) {
-                        DismissValue.DismissedToEnd -> {
+                        SwipeToDismissBoxValue.StartToEnd -> {
                             onSwipeBack()
                             true
                         }
 
-                        else -> {
-                            false
-                        }
+                        else -> false
                     }
                 },
-            )
-        SwipeToDismiss(
-            state = dismissState,
-            background = {
+                positionalThreshold = { it * 0.7f },
+            ),
+            enableDismissFromEndToStart = false,
+            backgroundContent = {
                 Box(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.background),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background),
                 )
             },
-            dismissContent = {
-                content()
-            },
-            directions = setOf(DismissDirection.StartToEnd),
-            dismissThresholds = { FractionalThreshold(0.8f) },
-        )
+        ) {
+            content()
+        }
     } else {
         content()
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -150,7 +150,6 @@
     <string name="look_and_feel_look_and_feel">الأسلوب</string>
     <string name="look_and_feel_post_navigation_gesture_mode">إيماءات التنقُّل بين الموضوعات</string>
     <string name="look_and_feel_post_navigation_gesture_mode_disabled">معطَّل</string>
-    <string name="look_and_feel_post_navigation_gesture_mode_swipe_left">اسحب يسارًا ترجع</string>
     <string name="look_and_feel_post_view">منظور الموضوعات</string>
     <string name="look_and_feel_post_view_card">بطائق</string>
     <string name="look_and_feel_post_view_list">قائمة</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -155,7 +155,6 @@
     <string name="look_and_feel_look_and_feel">Външен вид</string>
     <string name="look_and_feel_post_navigation_gesture_mode">Post navigation gestures</string>
     <string name="look_and_feel_post_navigation_gesture_mode_disabled">Disabled</string>
-    <string name="look_and_feel_post_navigation_gesture_mode_swipe_left">Swipe left to navigate back</string>
     <string name="look_and_feel_post_view">Изглед на публикациите</string>
     <string name="look_and_feel_post_view_card">Карта</string>
     <string name="look_and_feel_post_view_list">Списък</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -96,7 +96,7 @@
     <string name="look_and_feel_look_and_feel">Внешний вид и предпочтения</string>
     <string name="look_and_feel_post_navigation_gesture_mode">Жесты навигации по публикациям</string>
     <string name="look_and_feel_post_navigation_gesture_mode_disabled">Отключен</string>
-    <string name="look_and_feel_post_navigation_gesture_mode_swipe_left">Проведите пальцем слева, чтобы вернуться назад.</string>
+    <string name="look_and_feel_post_navigation_gesture_mode_swipe_right">Проведите пальцем слева, чтобы вернуться назад.</string>
     <string name="look_and_feel_post_view">Внешний вид постов</string>
     <string name="look_and_feel_post_view_card">Карточка</string>
     <string name="look_and_feel_post_view_list">Список</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -155,7 +155,6 @@
     <string name="look_and_feel_look_and_feel">Bak ve hisset</string>
     <string name="look_and_feel_post_navigation_gesture_mode">Gezinme sonrası hareketleri</string>
     <string name="look_and_feel_post_navigation_gesture_mode_disabled">Devre dışı</string>
-    <string name="look_and_feel_post_navigation_gesture_mode_swipe_left">Geri gitmek için sola kaydırın</string>
     <string name="look_and_feel_post_view">Gönderi Görünümü</string>
     <string name="look_and_feel_post_view_card">Kart</string>
     <string name="look_and_feel_post_view_list">Liste</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,7 +155,7 @@
     <string name="look_and_feel_look_and_feel">Look and feel</string>
     <string name="look_and_feel_post_navigation_gesture_mode">Post navigation gestures</string>
     <string name="look_and_feel_post_navigation_gesture_mode_disabled">Disabled</string>
-    <string name="look_and_feel_post_navigation_gesture_mode_swipe_left">Swipe left to navigate back</string>
+    <string name="look_and_feel_post_navigation_gesture_mode_swipe_right">Swipe right to navigate back</string>
     <string name="look_and_feel_post_view">Post View</string>
     <string name="look_and_feel_post_view_card">Card</string>
     <string name="look_and_feel_post_view_list">List</string>


### PR DESCRIPTION
Use M3 replacement.

Whats strange is that they named it "Swipe left" but dragging to right is swiping right? So I have corrected the naming to fit the behaviour.

This was the last accompanist dependency. Also the last M1 component.

Fixes #1479

https://github.com/LemmyNet/jerboa/assets/67873169/0a1e92d2-a1ff-4d0c-b9d7-01a4e519598d

