### PR TITLE
Fix Loading bar clipping behind content

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.jerboa.R
 import com.jerboa.api.ApiState
 import com.jerboa.datatypes.UserViewType
@@ -734,6 +735,7 @@ fun LoadingBar(padding: PaddingValues = PaddingValues(0.dp)) {
             Modifier
                 .fillMaxWidth()
                 .padding(padding)
+                .zIndex(99F)
                 .testTag("jerboa:loading"),
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/common/StateTriggers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/StateTriggers.kt
@@ -11,8 +11,8 @@ import com.jerboa.isScrolledToEnd
 @Composable
 fun TriggerWhenReachingEnd(
     listState: LazyListState,
-    loadMorePosts: () -> Unit,
     showPostAppendRetry: Boolean,
+    loadMorePosts: () -> Unit,
 ) {
     // observer when reached end of list
     val endOfListReached by remember {

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -287,11 +287,10 @@ fun CommunityActivity(
                                     accountViewModel,
                                 ) {
                                     communityViewModel.savePost(
-                                        form =
-                                            SavePost(
-                                                post_id = postView.post.id,
-                                                save = !postView.saved,
-                                            ),
+                                        form = SavePost(
+                                            post_id = postView.post.id,
+                                            save = !postView.saved,
+                                        ),
                                     )
                                 }
                             },

--- a/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
@@ -23,9 +23,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -44,7 +41,6 @@ import com.jerboa.feat.VoteType
 import com.jerboa.feat.doIfReadyElseDisplayInfo
 import com.jerboa.feat.newVote
 import com.jerboa.getCommentParentId
-import com.jerboa.isScrolledToEnd
 import com.jerboa.model.AccountViewModel
 import com.jerboa.model.InboxViewModel
 import com.jerboa.model.ReplyItem
@@ -55,9 +51,8 @@ import com.jerboa.ui.components.common.ApiEmptyText
 import com.jerboa.ui.components.common.ApiErrorText
 import com.jerboa.ui.components.common.JerboaLoadingBar
 import com.jerboa.ui.components.common.JerboaSnackbarHost
-import com.jerboa.ui.components.common.LoadingBar
+import com.jerboa.ui.components.common.TriggerWhenReachingEnd
 import com.jerboa.ui.components.common.getCurrentAccount
-import com.jerboa.ui.components.common.isLoading
 import com.jerboa.ui.components.common.isRefreshing
 import com.jerboa.ui.components.common.simpleVerticalScrollbar
 import com.jerboa.ui.components.privatemessage.PrivateMessage
@@ -231,26 +226,8 @@ fun InboxTabs(
                 InboxTab.Replies.ordinal -> {
                     val listState = rememberLazyListState()
 
-                    // observer when reached end of list
-                    val endOfListReached by remember {
-                        derivedStateOf {
-                            listState.isScrolledToEnd()
-                        }
-                    }
-
-                    // act when end of list reached
-                    if (endOfListReached) {
-                        LaunchedEffect(Unit) {
-                            account.doIfReadyElseDisplayInfo(
-                                appState,
-                                ctx,
-                                snackbarHostState,
-                                scope,
-                                siteViewModel,
-                            ) {
-                                inboxViewModel.appendReplies()
-                            }
-                        }
+                    TriggerWhenReachingEnd(listState, false) {
+                        inboxViewModel.appendReplies()
                     }
 
                     val goToComment = { crv: CommentReplyView ->
@@ -435,26 +412,8 @@ fun InboxTabs(
                 InboxTab.Mentions.ordinal -> {
                     val listState = rememberLazyListState()
 
-                    // observer when reached end of list
-                    val endOfListReached by remember {
-                        derivedStateOf {
-                            listState.isScrolledToEnd()
-                        }
-                    }
-
-                    // act when end of list reached
-                    if (endOfListReached) {
-                        LaunchedEffect(Unit) {
-                            account.doIfReadyElseDisplayInfo(
-                                appState,
-                                ctx,
-                                snackbarHostState,
-                                scope,
-                                siteViewModel,
-                            ) {
-                                inboxViewModel.appendMentions()
-                            }
-                        }
+                    TriggerWhenReachingEnd(listState, false) {
+                        inboxViewModel.appendMentions()
                     }
 
                     PullToRefreshBox(
@@ -631,26 +590,8 @@ fun InboxTabs(
                 InboxTab.Messages.ordinal -> {
                     val listState = rememberLazyListState()
 
-                    // observer when reached end of list
-                    val endOfListReached by remember {
-                        derivedStateOf {
-                            listState.isScrolledToEnd()
-                        }
-                    }
-
-                    // act when end of list reached
-                    if (endOfListReached) {
-                        LaunchedEffect(Unit) {
-                            account.doIfReadyElseDisplayInfo(
-                                appState,
-                                ctx,
-                                snackbarHostState,
-                                scope,
-                                siteViewModel,
-                            ) {
-                                inboxViewModel.appendMessages()
-                            }
-                        }
+                    TriggerWhenReachingEnd(listState, false) {
+                        inboxViewModel.appendMessages()
                     }
 
                     PullToRefreshBox(
@@ -672,9 +613,8 @@ fun InboxTabs(
                             }
                         },
                     ) {
-                        if (inboxViewModel.messagesRes.isLoading()) {
-                            LoadingBar()
-                        }
+                        JerboaLoadingBar(inboxViewModel.messagesRes)
+
                         when (val messagesRes = inboxViewModel.messagesRes) {
                             ApiState.Empty -> ApiEmptyText()
                             is ApiState.Failure -> ApiErrorText(messagesRes.msg)

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -24,9 +24,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -53,7 +50,6 @@ import com.jerboa.feat.VoteType
 import com.jerboa.feat.canMod
 import com.jerboa.feat.doIfReadyElseDisplayInfo
 import com.jerboa.feat.newVote
-import com.jerboa.isScrolledToEnd
 import com.jerboa.model.AccountViewModel
 import com.jerboa.model.AppSettingsViewModel
 import com.jerboa.model.PersonProfileViewModel
@@ -70,6 +66,7 @@ import com.jerboa.ui.components.common.ApiErrorText
 import com.jerboa.ui.components.common.JerboaLoadingBar
 import com.jerboa.ui.components.common.JerboaSnackbarHost
 import com.jerboa.ui.components.common.LoadingBar
+import com.jerboa.ui.components.common.TriggerWhenReachingEnd
 import com.jerboa.ui.components.common.apiErrorToast
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.common.getPostViewMode
@@ -662,11 +659,10 @@ fun UserTabs(
 
                                 val listState = rememberLazyListState()
 
-                                // observer when reached end of list
-                                val endOfListReached by remember {
-                                    derivedStateOf {
-                                        listState.isScrolledToEnd()
-                                    }
+                                TriggerWhenReachingEnd(listState, false) {
+                                    personProfileViewModel.appendData(
+                                        profileRes.data.person_view.person.id,
+                                    )
                                 }
 
                                 // Holds the un-expanded comment ids
@@ -694,15 +690,6 @@ fun UserTabs(
                                 }
 
                                 val showActionBarByDefault = true
-
-                                // act when end of list reached
-                                if (endOfListReached) {
-                                    LaunchedEffect(Unit) {
-                                        personProfileViewModel.appendData(
-                                            profileRes.data.person_view.person.id,
-                                        )
-                                    }
-                                }
 
                                 CommentNodes(
                                     nodes = nodes,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -148,7 +148,7 @@ fun PostListings(
         }
     }
 
-    TriggerWhenReachingEnd(listState, loadMorePosts, showPostAppendRetry)
+    TriggerWhenReachingEnd(listState, showPostAppendRetry, loadMorePosts)
 }
 
 @Preview

--- a/app/src/main/java/com/jerboa/ui/components/registrationapplications/RegistrationApplications.kt
+++ b/app/src/main/java/com/jerboa/ui/components/registrationapplications/RegistrationApplications.kt
@@ -31,8 +31,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,7 +54,6 @@ import com.jerboa.datatypes.samplePendingRegistrationApplicationView
 import com.jerboa.db.entity.Account
 import com.jerboa.db.entity.AnonAccount
 import com.jerboa.feat.doIfReadyElseDisplayInfo
-import com.jerboa.isScrolledToEnd
 import com.jerboa.model.RegistrationApplicationsViewModel
 import com.jerboa.model.SiteViewModel
 import com.jerboa.ui.components.common.ApiEmptyText
@@ -66,6 +63,7 @@ import com.jerboa.ui.components.common.JerboaLoadingBar
 import com.jerboa.ui.components.common.MarkdownTextField
 import com.jerboa.ui.components.common.MyMarkdownText
 import com.jerboa.ui.components.common.TimeAgo
+import com.jerboa.ui.components.common.TriggerWhenReachingEnd
 import com.jerboa.ui.components.common.UnreadOrAllOptionsDropDown
 import com.jerboa.ui.components.common.isRefreshing
 import com.jerboa.ui.components.common.simpleVerticalScrollbar
@@ -156,25 +154,15 @@ fun RegistrationApplications(
 ) {
     val listState = rememberLazyListState()
 
-    // observer when reached end of list
-    val endOfListReached by remember {
-        derivedStateOf {
-            listState.isScrolledToEnd()
-        }
-    }
-
-    // act when end of list reached
-    if (endOfListReached) {
-        LaunchedEffect(Unit) {
-            account.doIfReadyElseDisplayInfo(
-                appState,
-                ctx,
-                snackbarHostState,
-                scope,
-                siteViewModel,
-            ) {
-                registrationApplicationsViewModel.appendApplications()
-            }
+    TriggerWhenReachingEnd(listState, false) {
+        account.doIfReadyElseDisplayInfo(
+            appState,
+            ctx,
+            snackbarHostState,
+            scope,
+            siteViewModel,
+        ) {
+            registrationApplicationsViewModel.appendApplications()
         }
     }
 

--- a/app/src/main/java/com/jerboa/ui/components/reports/ReportsActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/reports/ReportsActivity.kt
@@ -23,9 +23,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -41,7 +38,6 @@ import com.jerboa.api.ApiState
 import com.jerboa.db.entity.Account
 import com.jerboa.feat.BlurNSFW
 import com.jerboa.feat.doIfReadyElseDisplayInfo
-import com.jerboa.isScrolledToEnd
 import com.jerboa.model.AccountViewModel
 import com.jerboa.model.ReportsViewModel
 import com.jerboa.model.SiteViewModel
@@ -49,6 +45,7 @@ import com.jerboa.ui.components.common.ApiEmptyText
 import com.jerboa.ui.components.common.ApiErrorText
 import com.jerboa.ui.components.common.JerboaLoadingBar
 import com.jerboa.ui.components.common.JerboaSnackbarHost
+import com.jerboa.ui.components.common.TriggerWhenReachingEnd
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.common.isRefreshing
 import com.jerboa.ui.components.common.simpleVerticalScrollbar
@@ -195,25 +192,15 @@ fun ReportsTabs(
                 ReportsTab.Posts.ordinal -> {
                     val listState = rememberLazyListState()
 
-                    // observer when reached end of list
-                    val endOfListReached by remember {
-                        derivedStateOf {
-                            listState.isScrolledToEnd()
-                        }
-                    }
-
-                    // act when end of list reached
-                    if (endOfListReached) {
-                        LaunchedEffect(Unit) {
-                            account.doIfReadyElseDisplayInfo(
-                                appState,
-                                ctx,
-                                snackbarHostState,
-                                scope,
-                                siteViewModel,
-                            ) {
-                                reportsViewModel.appendPostReports()
-                            }
+                    TriggerWhenReachingEnd(listState, false) {
+                        account.doIfReadyElseDisplayInfo(
+                            appState,
+                            ctx,
+                            snackbarHostState,
+                            scope,
+                            siteViewModel,
+                        ) {
+                            reportsViewModel.appendPostReports()
                         }
                     }
 
@@ -294,25 +281,15 @@ fun ReportsTabs(
                 ReportsTab.Comments.ordinal -> {
                     val listState = rememberLazyListState()
 
-                    // observer when reached end of list
-                    val endOfListReached by remember {
-                        derivedStateOf {
-                            listState.isScrolledToEnd()
-                        }
-                    }
-
-                    // act when end of list reached
-                    if (endOfListReached) {
-                        LaunchedEffect(Unit) {
-                            account.doIfReadyElseDisplayInfo(
-                                appState,
-                                ctx,
-                                snackbarHostState,
-                                scope,
-                                siteViewModel,
-                            ) {
-                                reportsViewModel.appendCommentReports()
-                            }
+                    TriggerWhenReachingEnd(listState, false) {
+                        account.doIfReadyElseDisplayInfo(
+                            appState,
+                            ctx,
+                            snackbarHostState,
+                            scope,
+                            siteViewModel,
+                        ) {
+                            reportsViewModel.appendCommentReports()
                         }
                     }
 
@@ -386,25 +363,15 @@ fun ReportsTabs(
                 ReportsTab.Messages.ordinal -> {
                     val listState = rememberLazyListState()
 
-                    // observer when reached end of list
-                    val endOfListReached by remember {
-                        derivedStateOf {
-                            listState.isScrolledToEnd()
-                        }
-                    }
-
-                    // act when end of list reached
-                    if (endOfListReached) {
-                        LaunchedEffect(Unit) {
-                            account.doIfReadyElseDisplayInfo(
-                                appState,
-                                ctx,
-                                snackbarHostState,
-                                scope,
-                                siteViewModel,
-                            ) {
-                                reportsViewModel.appendMessageReports()
-                            }
+                    TriggerWhenReachingEnd(listState, false) {
+                        account.doIfReadyElseDisplayInfo(
+                            appState,
+                            ctx,
+                            snackbarHostState,
+                            scope,
+                            siteViewModel,
+                        ) {
+                            reportsViewModel.appendMessageReports()
                         }
                     }
 

--- a/app/src/main/java/com/jerboa/ui/components/viewvotes/comment/CommentLikesActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/viewvotes/comment/CommentLikesActivity.kt
@@ -7,22 +7,18 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.JerboaAppState
 import com.jerboa.R
 import com.jerboa.api.ApiState
-import com.jerboa.isScrolledToEnd
 import com.jerboa.model.CommentLikesViewModel
 import com.jerboa.ui.components.common.ApiEmptyText
 import com.jerboa.ui.components.common.ApiErrorText
 import com.jerboa.ui.components.common.JerboaLoadingBar
 import com.jerboa.ui.components.common.SimpleTopAppBar
+import com.jerboa.ui.components.common.TriggerWhenReachingEnd
 import com.jerboa.ui.components.common.isRefreshing
 import com.jerboa.ui.components.viewvotes.ViewVotesBody
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommentId
@@ -49,18 +45,8 @@ fun CommentLikesActivity(
 
             val listState = rememberLazyListState()
 
-            // observer when reached end of list
-            val endOfListReached by remember {
-                derivedStateOf {
-                    listState.isScrolledToEnd()
-                }
-            }
-
-            // act when end of list reached
-            if (endOfListReached) {
-                LaunchedEffect(Unit) {
-                    commentLikesViewModel.appendLikes()
-                }
+            TriggerWhenReachingEnd(listState, false) {
+                commentLikesViewModel.appendLikes()
             }
 
             PullToRefreshBox(

--- a/app/src/main/java/com/jerboa/ui/components/viewvotes/post/PostLikesActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/viewvotes/post/PostLikesActivity.kt
@@ -7,22 +7,18 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.JerboaAppState
 import com.jerboa.R
 import com.jerboa.api.ApiState
-import com.jerboa.isScrolledToEnd
 import com.jerboa.model.PostLikesViewModel
 import com.jerboa.ui.components.common.ApiEmptyText
 import com.jerboa.ui.components.common.ApiErrorText
 import com.jerboa.ui.components.common.JerboaLoadingBar
 import com.jerboa.ui.components.common.SimpleTopAppBar
+import com.jerboa.ui.components.common.TriggerWhenReachingEnd
 import com.jerboa.ui.components.common.isRefreshing
 import com.jerboa.ui.components.viewvotes.ViewVotesBody
 import it.vercruysse.lemmyapi.v0x19.datatypes.PostId
@@ -49,18 +45,8 @@ fun PostLikesActivity(
 
             val listState = rememberLazyListState()
 
-            // observer when reached end of list
-            val endOfListReached by remember {
-                derivedStateOf {
-                    listState.isScrolledToEnd()
-                }
-            }
-
-            // act when end of list reached
-            if (endOfListReached) {
-                LaunchedEffect(Unit) {
-                    postLikesViewModel.appendLikes()
-                }
+            TriggerWhenReachingEnd(listState, false) {
+                postLikesViewModel.appendLikes()
             }
 
             PullToRefreshBox(


### PR DESCRIPTION
Fixes #1539 

The MarkdownView seems to render later causing it, to be drawn over the loading bar. A simple zindex fixes this.

![image](https://github.com/LemmyNet/jerboa/assets/67873169/cfec4dc2-7ce3-49ef-a83c-6008de79c2a1)

Also noticed this

> This overload of AndroidView does not automatically pool or reuse Views. If placed inside of a reusable container (including inside a LazyRow or LazyColumn), the View instances will always be discarded and recreated if the composition hierarchy containing the AndroidView changes, even if its group structure did not change and the View could have conceivably been reused.
To opt-in for View reuse, call the overload of AndroidView that accepts an onReset callback, and provide a non-null implementation for this callback. Since it is expensive to discard and recreate View instances, reusing Views can lead to noticeable performance improvements — especially when building a scrolling list of AndroidViews. It is highly recommended to opt-in to View reuse when possible.
AndroidView will not clip its content to the layout bounds. Use View. setClipToOutline on the child View to clip the contents, if desired. Developers will likely want to do this with all subclasses of SurfaceView to keep its contents contained.

I'll play around with it when I have some time.