### PR TITLE
Hide Metadata outline when no metadata is shown

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -1757,7 +1757,8 @@ fun PostListingHeaderPreview() {
 @Composable
 fun MetadataCard(post: Post) {
     val embedTitle = post.embed_title
-    if (embedTitle != null) {
+    // If there is a valid title or description show it
+    if (embedTitle != null && (post.name != embedTitle || post.embed_description != null)) {
         OutlinedCard(
             shape = MaterialTheme.shapes.medium,
             modifier =


### PR DESCRIPTION
Fixes #1547 

![image](https://github.com/LemmyNet/jerboa/assets/67873169/975219e2-179a-44d9-9f23-63de22f94867)

Stills shows description
![image](https://github.com/LemmyNet/jerboa/assets/67873169/6ee3662d-cd65-4579-9ce8-51e17d474be5)
