### PR TITLE
Increase fontsize votes slightly

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
@@ -207,11 +207,11 @@ private fun VoteIndicator(
         Text(
             text = data,
             color = scoreColor(myVote = myVote),
-            style = MaterialTheme.typography.labelMedium,
+            style = MaterialTheme.typography.labelLarge,
             modifier = Modifier.padding(horizontal = 0.dp),
         )
         iconAndDescription?.let {
-            val size = MaterialTheme.typography.labelMedium.fontSize.value.dp
+            val size = MaterialTheme.typography.labelLarge.fontSize.value.dp
             Icon(
                 imageVector = iconAndDescription.first,
                 contentDescription = iconAndDescription.second,


### PR DESCRIPTION
I think the fontsize of  voting types are a bit too small. We can slightly increase it and it will still be capable of showing all the voting types. All though it will be very rare that someone has enabled all of them. I believe its better to cater to the common case which will be showing two voting types.

After: (14 SP)
![image](https://github.com/LemmyNet/jerboa/assets/67873169/4f676793-e61d-423b-8799-72948a8323dd)

Before: (12 SP)

![image](https://github.com/LemmyNet/jerboa/assets/67873169/f6056b75-1431-4371-89ed-86db2280e2ff)
