### PR TITLE
Fix edgecase with legacy show_scores

### DIFF
--- a/app/src/main/java/com/jerboa/model/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/SiteViewModel.kt
@@ -226,12 +226,30 @@ class SiteViewModel(private val accountRepository: AccountRepository) : ViewMode
 
     // For the current default, just use Upvotes / Downvotes
     fun voteDisplayMode(): LocalUserVoteDisplayMode {
+        val api = API.getInstanceOrNull()
+
+        return if (api == null || api.FF.hidePost()) {
+            newVoteDisplayMode()
+        } else {
+            legacyVoteDisplayMode()
+        }
+    }
+
+    private fun newVoteDisplayMode(): LocalUserVoteDisplayMode {
         return when (val res = siteRes) {
             is ApiState.Success ->
-                res.data.my_user?.local_user_view?.local_user_vote_display_mode
-                    ?: LocalUserVoteDisplayMode.default(res.data.my_user?.local_user_view?.local_user?.show_scores)
+                res.data.my_user?.local_user_view?.local_user_vote_display_mode ?: LocalUserVoteDisplayMode.default()
 
             else -> LocalUserVoteDisplayMode.default()
+        }
+    }
+
+    private fun legacyVoteDisplayMode(): LocalUserVoteDisplayMode {
+        return when (val res = siteRes) {
+            is ApiState.Success ->
+                LocalUserVoteDisplayMode.default(res.data.my_user?.local_user_view?.local_user?.show_scores ?: true)
+
+            else -> LocalUserVoteDisplayMode.default(true) // Legacy default
         }
     }
 

--- a/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
@@ -145,7 +145,7 @@ fun SettingsForm(
 
     val showNsfwState = remember { mutableStateOf(luv?.local_user?.show_nsfw ?: false) }
     val showAvatarsState = remember { mutableStateOf(luv?.local_user?.show_avatars ?: false) }
-    val showScoresStateLegacy = remember { mutableStateOf(luv?.local_user?.show_scores ?: false) }
+    val showScoresStateLegacy = remember { mutableStateOf(luv?.local_user?.show_scores ?: true) }
     val showScoresState = remember { mutableStateOf(luv?.local_user_vote_display_mode?.score ?: false) }
     val showUpvotesState = remember { mutableStateOf(luv?.local_user_vote_display_mode?.upvotes ?: false) }
     val showDownvotesState = remember { mutableStateOf(luv?.local_user_vote_display_mode?.downvotes ?: false) }


### PR DESCRIPTION
This fixes the show_scores for pre 0.19.4 anon users. This maintains the previous behaviour.