### PR TITLE
Remove renovate bot from git cliff changelogs.

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -72,6 +72,9 @@ commit_preprocessors = [
   # remove issue numbers from commits
   { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
+commit_parsers = [
+  { field = "author.name", pattern = "renovate", skip = true },
+]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers

--- a/cliff.toml
+++ b/cliff.toml
@@ -28,6 +28,7 @@ body = """
     {%- endif %}
 {%- endfor -%}
 
+{%- if github -%}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
   {% raw %}\n{% endraw -%}
   ## New Contributors
@@ -38,6 +39,7 @@ body = """
       [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
     {%- endif %}
 {%- endfor -%}
+{%- endif -%}
 
 {% if version %}
     {% if previous.version %}


### PR DESCRIPTION
- Fixes #1562