### PR TITLE
Fix multiple spoiler blocks displaying incorrectly (#1577)

### DIFF
--- a/app/src/main/java/com/jerboa/util/markwon/MarkwonSpoilerPlugin.kt
+++ b/app/src/main/java/com/jerboa/util/markwon/MarkwonSpoilerPlugin.kt
@@ -113,17 +113,19 @@ class MarkwonSpoilerPlugin(
                                 textView.cancelPendingInputEvents()
                                 open = !open
 
+                                val spoilerStartCurrent = spanned.getSpanStart(spoilerTitle)
+
                                 spanned.replace(
-                                    spoilerStart,
-                                    spoilerStart + spoilerTitle.length,
+                                    spoilerStartCurrent,
+                                    spoilerStartCurrent + spoilerTitle.length,
                                     getSpoilerTitle(open),
                                 )
                                 if (open) {
-                                    spanned.insert(spoilerStart + spoilerTitle.length, spoilerContent)
+                                    spanned.insert(spoilerStartCurrent + spoilerTitle.length, spoilerContent)
                                 } else {
                                     spanned.replace(
-                                        spoilerStart + spoilerTitle.length,
-                                        spoilerStart + spoilerTitle.length + spoilerContent.length,
+                                        spoilerStartCurrent + spoilerTitle.length,
+                                        spoilerStartCurrent + spoilerTitle.length + spoilerContent.length,
                                         "",
                                     )
                                 }


### PR DESCRIPTION
- The spans are now overwriting the correct text even if the text has changed since the first parsing
- Fixes #1577