### PR TITLE
Some material 3 cleanups.

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -474,7 +474,7 @@ fun communityNameShown(community: Community): String =
 
 fun hostName(url: String): String? =
     try {
-        URL(url).host
+        URL(url).host.replace("www.", "")
     } catch (e: MalformedURLException) {
         null
     }

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -474,10 +474,15 @@ fun communityNameShown(community: Community): String =
 
 fun hostName(url: String): String? =
     try {
-        URL(url).host.replace("www.", "")
+        URL(url).host
     } catch (e: MalformedURLException) {
         null
     }
+
+/**
+ * Used for the post listing hostname preview
+ */
+fun hostNameCleaned(url: String): String? = hostName(url)?.replace("www.", "")
 
 enum class UnreadOrAll {
     All,

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -82,7 +82,6 @@ import com.jerboa.ui.theme.MEDIUM_PADDING
 import com.jerboa.ui.theme.SMALL_PADDING
 import com.jerboa.ui.theme.XXL_PADDING
 import com.jerboa.ui.theme.colorList
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.Comment
 import it.vercruysse.lemmyapi.datatypes.CommentId
 import it.vercruysse.lemmyapi.datatypes.CommentView
@@ -711,7 +710,10 @@ fun PostAndCommunityContextHeader(
         Row(
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(text = stringResource(R.string.comment_node_in), color = MaterialTheme.colorScheme.onBackground.muted)
+            Text(
+                text = stringResource(R.string.comment_node_in),
+                color = MaterialTheme.colorScheme.outline,
+            )
             CommunityLink(
                 community = community,
                 onClick = onCommunityClick,
@@ -860,7 +862,7 @@ fun CommentFooterLine(
                     if (commentView.saved) {
                         MaterialTheme.colorScheme.primary
                     } else {
-                        MaterialTheme.colorScheme.onBackground.muted
+                        MaterialTheme.colorScheme.outline
                     },
                 account = account,
             )

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -42,7 +42,6 @@ import com.jerboa.ui.components.common.VoteGeneric
 import com.jerboa.ui.theme.LARGE_PADDING
 import com.jerboa.ui.theme.SMALL_PADDING
 import com.jerboa.ui.theme.XXL_PADDING
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.Community
 import it.vercruysse.lemmyapi.datatypes.LocalUserVoteDisplayMode
 import it.vercruysse.lemmyapi.datatypes.Person
@@ -194,7 +193,7 @@ fun CommentMentionNodeFooterLine(
                     if (personMentionView.person_mention.read) {
                         MaterialTheme.colorScheme.primary
                     } else {
-                        MaterialTheme.colorScheme.onBackground.muted
+                        MaterialTheme.colorScheme.outline
                     },
                 account = account,
             )
@@ -225,7 +224,7 @@ fun CommentMentionNodeFooterLine(
                     if (personMentionView.saved) {
                         MaterialTheme.colorScheme.primary
                     } else {
-                        MaterialTheme.colorScheme.onBackground.muted
+                        MaterialTheme.colorScheme.outline
                     },
                 account = account,
             )

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
@@ -41,7 +41,6 @@ import com.jerboa.ui.components.common.VoteGeneric
 import com.jerboa.ui.theme.LARGE_PADDING
 import com.jerboa.ui.theme.SMALL_PADDING
 import com.jerboa.ui.theme.XXL_PADDING
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.CommentReplyView
 import it.vercruysse.lemmyapi.datatypes.Community
 import it.vercruysse.lemmyapi.datatypes.LocalUserVoteDisplayMode
@@ -177,7 +176,7 @@ fun CommentReplyNodeInboxFooterLine(
                     if (commentReplyView.comment_reply.read) {
                         MaterialTheme.colorScheme.primary
                     } else {
-                        MaterialTheme.colorScheme.onBackground.muted
+                        MaterialTheme.colorScheme.outline
                     },
                 account = account,
             )
@@ -199,7 +198,7 @@ fun CommentReplyNodeInboxFooterLine(
                     if (commentReplyView.saved) {
                         MaterialTheme.colorScheme.primary
                     } else {
-                        MaterialTheme.colorScheme.onBackground.muted
+                        MaterialTheme.colorScheme.outline
                     },
                 account = account,
             )

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -166,7 +166,6 @@ fun BottomAppBarAll(
                             textAlign = TextAlign.Center,
                             fontSize = TextUnit(10f, TextUnitType.Sp),
                             text = stringResource(tab.textId),
-                            color = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 },
@@ -340,7 +339,7 @@ fun ActionBarButton(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     text: String? = null,
-    contentColor: Color = MaterialTheme.colorScheme.onBackground.muted,
+    contentColor: Color = MaterialTheme.colorScheme.outline,
     noClick: Boolean = false,
     account: Account,
     requiresAccount: Boolean = true,
@@ -371,7 +370,7 @@ fun ActionBarButton(
             Text(
                 text = text,
                 color = contentColor,
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.labelMedium,
             )
         }
     }
@@ -399,7 +398,7 @@ fun ActionBarButtonAndBadge(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     text: String? = null,
-    contentColor: Color = MaterialTheme.colorScheme.onBackground.muted,
+    contentColor: Color = MaterialTheme.colorScheme.outline,
     noClick: Boolean = false,
     account: Account,
     requiresAccount: Boolean = true,
@@ -451,12 +450,12 @@ fun ActionBarButtonAndBadge(
 fun DotSpacer(
     modifier: Modifier = Modifier,
     padding: Dp = 0.dp,
-    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    style: TextStyle = MaterialTheme.typography.labelMedium,
 ) {
     Text(
         text = stringResource(R.string.app_bars_dot_spacer),
         style = style,
-        color = MaterialTheme.colorScheme.onBackground.muted,
+        color = MaterialTheme.colorScheme.outline,
         modifier = modifier.padding(horizontal = padding),
     )
 }
@@ -466,7 +465,7 @@ fun scoreColor(myVote: Int?): Color =
     when (myVote) {
         1 -> MaterialTheme.colorScheme.secondary
         -1 -> MaterialTheme.colorScheme.error
-        else -> MaterialTheme.colorScheme.onBackground.muted
+        else -> MaterialTheme.colorScheme.outline
     }
 
 @Composable
@@ -589,7 +588,7 @@ fun Sidebar(
                 ) {
                     MyMarkdownText(
                         markdown = it,
-                        color = MaterialTheme.colorScheme.onBackground.muted,
+                        color = MaterialTheme.colorScheme.outline,
                         onClick = {},
                     )
                 }
@@ -656,34 +655,47 @@ fun CommentsAndPosts(
     FlowRow {
         Text(
             text = stringResource(R.string.AppBars_users_day, siFormat(usersActiveDay)),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            color = MaterialTheme.colorScheme.outline,
         )
-        DotSpacer(style = MaterialTheme.typography.bodyMedium)
+        DotSpacer()
         Text(
             text = stringResource(R.string.AppBars_users_week, siFormat(usersActiveWeek)),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            color = MaterialTheme.colorScheme.outline,
         )
         DotSpacer(style = MaterialTheme.typography.bodyMedium)
         Text(
             text = stringResource(R.string.AppBars_users_month, siFormat(usersActiveMonth)),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            color = MaterialTheme.colorScheme.outline,
         )
-        DotSpacer(style = MaterialTheme.typography.bodyMedium)
+        DotSpacer()
         Text(
             text = stringResource(R.string.AppBars_users_6_months, siFormat(usersActiveHalfYear)),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            color = MaterialTheme.colorScheme.outline,
         )
-        DotSpacer(style = MaterialTheme.typography.bodyMedium)
+        DotSpacer()
         Text(
             text = stringResource(R.string.AppBars_posts, siFormat(postCount)),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            color = MaterialTheme.colorScheme.outline,
         )
-        DotSpacer(style = MaterialTheme.typography.bodyMedium)
+        DotSpacer()
         Text(
             text = stringResource(R.string.AppBars_comments, siFormat(commentCount)),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            color = MaterialTheme.colorScheme.outline,
         )
     }
+}
+
+@Preview
+@Composable
+fun CommentsAndPostsPreview() {
+    CommentsAndPosts(
+        usersActiveDay = 2,
+        usersActiveWeek = 22,
+        usersActiveMonth = 222,
+        usersActiveHalfYear = 2222,
+        postCount = 20,
+        commentCount = 5,
+    )
 }
 
 @SuppressLint("ComposableModifierFactory")
@@ -773,9 +785,7 @@ fun ActionTopBar(
                 enabled = formValid && !loading,
             ) {
                 if (loading) {
-                    CircularProgressIndicator(
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
+                    CircularProgressIndicator()
                 } else {
                     Icon(
                         imageVector = actionIcon,

--- a/app/src/main/java/com/jerboa/ui/components/common/DrawerItems.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/DrawerItems.kt
@@ -62,7 +62,6 @@ fun IconAndTextDrawerItem(
                     modifier = spacingMod.size(DRAWER_ITEM_SPACING),
                     icon = ico,
                     contentDescription = contentDescription,
-                    tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
             Text(
@@ -74,7 +73,6 @@ fun IconAndTextDrawerItem(
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.ArrowRight,
                 contentDescription = stringResource(R.string.dialog_moreOptions),
-                tint = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.size(24.dp),
             )
         }

--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -72,7 +72,6 @@ import com.jerboa.db.entity.isAnon
 import com.jerboa.imageInputStreamFromUri
 import com.jerboa.ui.theme.MARKDOWN_BAR_ICON_SIZE
 import com.jerboa.ui.theme.MEDIUM_PADDING
-import com.jerboa.ui.theme.muted
 import kotlinx.coroutines.launch
 
 @Composable
@@ -138,8 +137,6 @@ fun MarkdownTextField(
                     ),
                 colors =
                     TextFieldDefaults.colors(
-                        focusedTextColor = MaterialTheme.colorScheme.onSurface,
-                        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
                         focusedContainerColor = Color.Transparent,
                         unfocusedContainerColor = Color.Transparent,
                         focusedIndicatorColor = Color.Transparent,
@@ -196,7 +193,6 @@ fun CreateLinkDialog(
                 Text(
                     text = stringResource(R.string.input_fields_insert_link),
                     style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 OutlinedTextField(
                     value = text,
@@ -222,7 +218,7 @@ fun CreateLinkDialog(
             ) {
                 Text(
                     text = stringResource(R.string.input_fields_cancel),
-                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    color = MaterialTheme.colorScheme.outline,
                 )
             }
         },
@@ -272,7 +268,7 @@ fun ShowPreviewDialog(
             ) {
                 Text(
                     text = stringResource(R.string.input_fields_ok),
-                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    color = MaterialTheme.colorScheme.outline,
                 )
             }
         },
@@ -428,7 +424,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.Preview,
                 contentDescription = stringResource(R.string.markdownHelper_preview),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -437,7 +433,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.Link,
                 contentDescription = stringResource(R.string.markdownHelper_insertLink),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -445,14 +441,12 @@ fun MarkdownHelperBar(
             enabled = !imageUploading,
         ) {
             if (imageUploading) {
-                CircularProgressIndicator(
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                CircularProgressIndicator()
             } else {
                 Icon(
                     imageVector = Icons.Outlined.Image,
                     contentDescription = stringResource(R.string.markdownHelper_insertImage),
-                    tint = MaterialTheme.colorScheme.onBackground.muted,
+                    tint = MaterialTheme.colorScheme.outline,
                 )
             }
         }
@@ -468,7 +462,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.FormatBold,
                 contentDescription = stringResource(R.string.markdownHelper_formatBold),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -483,7 +477,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.FormatItalic,
                 contentDescription = stringResource(R.string.markdownHelper_formatItalic),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -499,7 +493,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.FormatQuote,
                 contentDescription = stringResource(R.string.markdownHelper_insertQuote),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -515,7 +509,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.FormatListBulleted,
                 contentDescription = stringResource(R.string.markdownHelper_insertList),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -532,7 +526,7 @@ fun MarkdownHelperBar(
                 painter = painterResource(R.drawable.emergency_home_fill0_wght400_grad0_opsz48),
                 contentDescription = stringResource(R.string.markdownHelper_insertSpoiler),
                 modifier = Modifier.size(MARKDOWN_BAR_ICON_SIZE),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -548,7 +542,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.Title,
                 contentDescription = stringResource(R.string.markdownHelper_insertHeader),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -563,7 +557,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.Code,
                 contentDescription = stringResource(R.string.markdownHelper_insertCode),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -578,7 +572,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.FormatStrikethrough,
                 contentDescription = stringResource(R.string.markdownHelper_formatStrikethrough),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -593,7 +587,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.Subscript,
                 contentDescription = stringResource(R.string.markdownHelper_formatSubscript),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
         IconButton(
@@ -608,7 +602,7 @@ fun MarkdownHelperBar(
             Icon(
                 imageVector = Icons.Outlined.Superscript,
                 contentDescription = stringResource(R.string.markdownHelper_formatSuperscript),
-                tint = MaterialTheme.colorScheme.onBackground.muted,
+                tint = MaterialTheme.colorScheme.outline,
             )
         }
     }

--- a/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
@@ -251,7 +251,7 @@ object MarkdownHelper {
                 )
             },
             update = { textView ->
-                previewMarkwon!!.setMarkdown(textView, markdown)
+                previewMarkwon?.setMarkdown(textView, markdown)
             },
             modifier = modifier,
         )

--- a/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
@@ -1,7 +1,6 @@
 package com.jerboa.ui.components.common
 
 import android.os.Build
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -12,7 +11,12 @@ import androidx.compose.ui.autofill.AutofillTree
 import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
@@ -65,5 +69,12 @@ fun Modifier.onAutofill(
         }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 fun Modifier.customMarquee(): Modifier = this.basicMarquee(initialDelayMillis = 4_000)
+
+fun Modifier.fadingEdge(brush: Brush) =
+    this
+        .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+        .drawWithContent {
+            drawContent()
+            drawRect(brush = brush, blendMode = BlendMode.DstIn)
+        }

--- a/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
@@ -38,7 +38,6 @@ import com.jerboa.ui.theme.LARGER_ICON_SIZE
 import com.jerboa.ui.theme.LARGER_ICON_THUMBNAIL_SIZE
 import com.jerboa.ui.theme.MAX_IMAGE_SIZE
 import com.jerboa.ui.theme.THUMBNAIL_SIZE
-import com.jerboa.ui.theme.muted
 import com.jerboa.util.BlurTransformation
 
 @Composable
@@ -271,7 +270,7 @@ fun ColumnScope.PickImage(
         } else {
             Text(
                 text = stringResource(R.string.pictrs_image_upload_image),
-                color = MaterialTheme.colorScheme.onBackground.muted,
+                color = MaterialTheme.colorScheme.outline,
             )
         }
     }

--- a/app/src/main/java/com/jerboa/ui/components/common/TextBadge.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TextBadge.kt
@@ -1,6 +1,5 @@
 package com.jerboa.ui.components.common
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -15,12 +14,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.jerboa.hostName
-import com.jerboa.ui.theme.muted
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TextBadge(
     text: String,
@@ -61,9 +60,9 @@ fun ItemAndInstanceTitle(
     local: Boolean,
     onClick: (() -> Unit)?,
     itemColor: Color = MaterialTheme.colorScheme.primary,
-    itemStyle: TextStyle = MaterialTheme.typography.bodyMedium,
-    instanceColor: Color = MaterialTheme.colorScheme.onSurface.muted,
-    instanceStyle: TextStyle = MaterialTheme.typography.bodySmall,
+    itemStyle: TextStyle = MaterialTheme.typography.labelMedium,
+    instanceColor: Color = MaterialTheme.colorScheme.outline,
+    instanceStyle: TextStyle = MaterialTheme.typography.labelSmall,
 ) {
     val text = remember(title, local, itemColor) {
         val serverStr = if (!local && actorId != null) {
@@ -81,6 +80,7 @@ fun ItemAndInstanceTitle(
             serverStr?.let { server ->
                 withStyle(
                     style = instanceStyle.toSpanStyle().copy(
+                        fontFamily = FontFamily.Monospace,
                         color = instanceColor,
                     ),
                 ) {
@@ -100,5 +100,16 @@ fun ItemAndInstanceTitle(
         text = text,
         maxLines = 1,
         modifier = baseModifier.customMarquee(),
+    )
+}
+
+@Composable
+@Preview
+fun ItemInstanceAndTitlePreview() {
+    ItemAndInstanceTitle(
+        title = "lemmydev",
+        actorId = "https://lemmy.ml/u/lemmydev",
+        local = false,
+        onClick = {},
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
@@ -40,7 +40,6 @@ import com.jerboa.feat.formatPercent
 import com.jerboa.feat.upvotePercent
 import com.jerboa.formatDuration
 import com.jerboa.ui.theme.SMALL_PADDING
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.LocalUserVoteDisplayMode
 import java.time.Instant
 import java.time.format.DateTimeParseException
@@ -69,7 +68,7 @@ fun TimeAgo(
     Row(modifier = modifier) {
         Text(
             text = afterPreceding,
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            color = MaterialTheme.colorScheme.outline,
             style = MaterialTheme.typography.labelMedium,
         )
 
@@ -86,7 +85,7 @@ fun TimeAgo(
                 Text(
                     text = "($updatedPretty)",
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    color = MaterialTheme.colorScheme.outline,
                     fontStyle = FontStyle.Italic,
                 )
             }
@@ -213,7 +212,7 @@ private fun VoteIndicator(
         Text(
             text = data,
             color = scoreColor(myVote = myVote),
-            style = MaterialTheme.typography.labelLarge,
+            style = MaterialTheme.typography.labelMedium,
             modifier = Modifier.padding(horizontal = 0.dp),
         )
         iconAndDescription?.let {

--- a/app/src/main/java/com/jerboa/ui/components/common/VoteHelpers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/VoteHelpers.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.res.vectorResource
 import com.jerboa.R
 import com.jerboa.db.entity.Account
 import com.jerboa.feat.VoteType
-import com.jerboa.ui.theme.muted
 
 @Composable
 fun VoteGeneric(
@@ -58,8 +57,7 @@ fun upvoteIconAndColor(myVote: Int?): Pair<ImageVector, Color> =
         else ->
             Pair(
                 ImageVector.vectorResource(id = R.drawable.up_outline),
-                MaterialTheme
-                    .colorScheme.onBackground.muted,
+                MaterialTheme.colorScheme.outline,
             )
     }
 
@@ -74,7 +72,6 @@ fun downvoteIconAndColor(myVote: Int?): Pair<ImageVector, Color> =
         else ->
             Pair(
                 ImageVector.vectorResource(id = R.drawable.down_outline),
-                MaterialTheme
-                    .colorScheme.onBackground.muted,
+                MaterialTheme.colorScheme.outline,
             )
     }

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -55,7 +55,6 @@ import com.jerboa.ui.components.common.customMarquee
 import com.jerboa.ui.theme.ACTION_BAR_ICON_SIZE
 import com.jerboa.ui.theme.DRAWER_BANNER_SIZE
 import com.jerboa.ui.theme.MEDIUM_PADDING
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.CommunityView
 import it.vercruysse.lemmyapi.dto.SortType
 import it.vercruysse.lemmyapi.dto.SubscribedType
@@ -99,7 +98,6 @@ fun CommunityTopSection(
                 Text(
                     text = communityView.community.title,
                     style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
                 )
             }
             Row {
@@ -109,8 +107,8 @@ fun CommunityTopSection(
                             R.string.community_users_month,
                             communityView.counts.users_active_month,
                         ),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.outline,
                 )
             }
             Row {

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityLink.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityLink.kt
@@ -44,7 +44,7 @@ fun CommunityName(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)?,
     color: Color = MaterialTheme.colorScheme.primary,
-    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    style: TextStyle = MaterialTheme.typography.labelMedium,
 ) {
     ItemAndInstanceTitle(
         title = community.title,
@@ -78,7 +78,7 @@ fun CommunityLink(
     spacing: Dp = SMALL_PADDING,
     size: Dp = ICON_SIZE,
     thumbnailSize: Int = ICON_THUMBNAIL_SIZE,
-    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    style: TextStyle = MaterialTheme.typography.labelMedium,
     onClick: (community: Community) -> Unit,
     clickable: Boolean = true,
     showDefaultIcon: Boolean,
@@ -119,7 +119,6 @@ fun CommunityLink(
             usersPerMonth?.also {
                 Text(
                     text = stringResource(R.string.community_link_users_month, usersPerMonth),
-                    color = MaterialTheme.colorScheme.onSurface,
                 )
             }
         }

--- a/app/src/main/java/com/jerboa/ui/components/drawer/Drawer.kt
+++ b/app/src/main/java/com/jerboa/ui/components/drawer/Drawer.kt
@@ -3,7 +3,6 @@ package com.jerboa.ui.components.drawer
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -65,7 +64,6 @@ import com.jerboa.ui.theme.DRAWER_BANNER_SIZE
 import com.jerboa.ui.theme.LARGE_PADDING
 import com.jerboa.ui.theme.SMALL_PADDING
 import com.jerboa.ui.theme.XL_PADDING
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.Community
 import it.vercruysse.lemmyapi.datatypes.CommunityFollowerView
 import it.vercruysse.lemmyapi.datatypes.MyUserInfo
@@ -282,7 +280,7 @@ fun DrawerItemsMain(
                 Text(
                     text = stringResource(R.string.home_subscriptions),
                     modifier = Modifier.padding(LARGE_PADDING),
-                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    color = MaterialTheme.colorScheme.outline,
                 )
             }
             items(
@@ -447,7 +445,6 @@ fun DrawerHeader(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AvatarAndAccountName(
     account: Account,
@@ -467,7 +464,6 @@ fun AvatarAndAccountName(
             Text(
                 text = myPerson?.getDisplayName() ?: account.name,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.customMarquee(),
             )
             Text(

--- a/app/src/main/java/com/jerboa/ui/components/home/legal/SiteLegalScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/legal/SiteLegalScreen.kt
@@ -20,7 +20,6 @@ import com.jerboa.ui.components.common.LoadingBar
 import com.jerboa.ui.components.common.MyMarkdownText
 import com.jerboa.ui.components.common.SimpleTopAppBar
 import com.jerboa.ui.theme.MEDIUM_PADDING
-import com.jerboa.ui.theme.muted
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,7 +62,7 @@ fun SiteLegalScreen(
                             MyMarkdownText(
                                 modifier = Modifier.padding(horizontal = MEDIUM_PADDING),
                                 markdown = it,
-                                color = MaterialTheme.colorScheme.onBackground.muted,
+                                color = MaterialTheme.colorScheme.outline,
                                 onClick = {},
                             )
                         }

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
@@ -54,7 +54,6 @@ import com.jerboa.ui.components.common.TimeAgo
 import com.jerboa.ui.theme.MARKDOWN_BAR_ICON_SIZE
 import com.jerboa.ui.theme.MEDIUM_PADDING
 import com.jerboa.ui.theme.PROFILE_BANNER_SIZE
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.PersonView
 import it.vercruysse.lemmyapi.dto.SortType
 
@@ -115,7 +114,7 @@ fun PersonProfileTopSection(
             personView.person.bio?.also {
                 MyMarkdownText(
                     markdown = it,
-                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    color = MaterialTheme.colorScheme.outline,
                     onClick = {},
                 )
             }
@@ -128,12 +127,14 @@ fun CommentsAndPosts(personView: PersonView) {
     Row {
         Text(
             text = stringResource(R.string.person_profile_posts, personView.counts.post_count),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.outline,
         )
         DotSpacer(style = MaterialTheme.typography.bodyMedium)
         Text(
             text = stringResource(R.string.person_profile_comments, personView.counts.comment_count),
-            color = MaterialTheme.colorScheme.onBackground.muted,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.outline,
         )
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileLink.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileLink.kt
@@ -31,7 +31,7 @@ import it.vercruysse.lemmyapi.datatypes.PersonId
 fun PersonName(
     person: Person,
     color: Color = MaterialTheme.colorScheme.tertiary,
-    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    style: TextStyle = MaterialTheme.typography.labelMedium,
     isPostCreator: Boolean = false,
 ) {
     val name = person.getDisplayName()

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -84,7 +84,7 @@ import com.jerboa.feat.isReadyAndIfNotShowSimplifiedInfoToast
 import com.jerboa.feat.needBlur
 import com.jerboa.feat.simulateModerators
 import com.jerboa.getPostType
-import com.jerboa.hostName
+import com.jerboa.hostNameCleaned
 import com.jerboa.isSameInstance
 import com.jerboa.nsfwCheck
 import com.jerboa.rememberJerboaAppState
@@ -427,7 +427,8 @@ fun PostTitleAndThumbnail(
                 PostName(post = post, read = read, showIfRead = showIfRead)
                 post.url?.also { postUrl ->
                     if (!isSameInstance(postUrl, account.instance)) {
-                        val hostName = hostName(postUrl)
+                        val hostName = hostNameCleaned(postUrl)
+
                         hostName?.also {
                             Text(
                                 text = it,
@@ -1426,7 +1427,7 @@ fun PostListingList(
                     DotSpacer(modifier = centerMod)
                     postView.post.url?.also { postUrl ->
                         if (!isSameInstance(postUrl, account.instance)) {
-                            val hostName = hostName(postUrl)
+                            val hostName = hostNameCleaned(postUrl)
                             hostName?.also {
                                 Text(
                                     text = it,

--- a/app/src/main/java/com/jerboa/ui/components/post/composables/PostComposables.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/composables/PostComposables.kt
@@ -44,7 +44,6 @@ import com.jerboa.ui.components.common.PictrsUrlImage
 import com.jerboa.ui.theme.ICON_SIZE
 import com.jerboa.ui.theme.MEDIUM_PADDING
 import com.jerboa.ui.theme.THUMBNAIL_SIZE
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.Community
 
 @Composable
@@ -127,7 +126,7 @@ fun CreateEditPostBody(
             suggestedTitle?.let {
                 Text(
                     text = stringResource(R.string.create_post_copy_suggested_title, it),
-                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    color = MaterialTheme.colorScheme.outline,
                     modifier = Modifier.clickable { onNameChange(it) },
                 )
             }

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessage.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessage.kt
@@ -27,7 +27,6 @@ import com.jerboa.ui.components.person.PersonProfileLink
 import com.jerboa.ui.theme.LARGE_PADDING
 import com.jerboa.ui.theme.SMALL_PADDING
 import com.jerboa.ui.theme.XXL_PADDING
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.Person
 import it.vercruysse.lemmyapi.datatypes.PersonId
 import it.vercruysse.lemmyapi.datatypes.PrivateMessageView
@@ -61,7 +60,10 @@ fun PrivateMessageHeader(
         Row(
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(text = fromOrTo, color = MaterialTheme.colorScheme.onBackground.muted)
+            Text(
+                text = fromOrTo,
+                color = MaterialTheme.colorScheme.outline,
+            )
             PersonProfileLink(
                 person = otherPerson,
                 onClick = { onPersonClick(otherPerson.id) },
@@ -173,7 +175,7 @@ fun PrivateMessageFooterLine(
                         if (privateMessageView.private_message.read) {
                             MaterialTheme.colorScheme.primary
                         } else {
-                            MaterialTheme.colorScheme.onBackground.muted
+                            MaterialTheme.colorScheme.outline
                         },
                     account = account,
                 )

--- a/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
@@ -46,7 +46,6 @@ import com.jerboa.ui.components.common.MarkdownTextField
 import com.jerboa.ui.components.common.PickImage
 import com.jerboa.ui.components.common.PictrsBannerImage
 import com.jerboa.ui.theme.MEDIUM_PADDING
-import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.datatypes.SaveUserSettings
 import it.vercruysse.lemmyapi.dto.ListingType
 import it.vercruysse.lemmyapi.dto.SortType
@@ -97,7 +96,7 @@ fun ImageWithClose(
             // Hard to see close button without a contrasting background
             colors =
                 IconButtonDefaults.iconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.surface.muted,
+                    containerColor = MaterialTheme.colorScheme.outline,
                     contentColor = MaterialTheme.colorScheme.onSurface,
                 ),
         ) {

--- a/app/src/main/java/com/jerboa/ui/theme/Color.kt
+++ b/app/src/main/java/com/jerboa/ui/theme/Color.kt
@@ -2,11 +2,8 @@
 
 package com.jerboa.ui.theme
 
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
 fun beach(): Pair<JerboaColorScheme, JerboaColorScheme> {
@@ -1356,8 +1353,3 @@ fun dracula(): Pair<JerboaColorScheme, JerboaColorScheme> {
 
     return Pair(jerboaLight, jerboaDark)
 }
-
-val Color.muted get() = this.copy(alpha = 0.5F)
-
-val CARD_COLORS @Composable
-get() = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)


### PR DESCRIPTION
- Adding a fade to the post body preview.
- Getting rid of muted, using colorScheme.outlined instead.
- Making label-type text use label rather than body style.
- Getting rid of some unecessary surface and onSurface colors.
- Fixes #1608

Example:

![Screenshot_2024-08-06-15-10-57-43_c9298fda48802cf3e2d17cb10a48759f](https://github.com/user-attachments/assets/cde3d463-6a40-4f37-836a-a7d3dc5503ff)
