### PR TITLE
Adding post divider back.

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -1,10 +1,13 @@
 package com.jerboa.ui.components.post
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
@@ -25,6 +28,7 @@ import com.jerboa.feat.default
 import com.jerboa.rememberJerboaAppState
 import com.jerboa.ui.components.common.RetryLoadingPosts
 import com.jerboa.ui.components.common.TriggerWhenReachingEnd
+import com.jerboa.ui.theme.SMALL_PADDING
 import it.vercruysse.lemmyapi.datatypes.Community
 import it.vercruysse.lemmyapi.datatypes.LocalUserVoteDisplayMode
 import it.vercruysse.lemmyapi.datatypes.Person
@@ -139,6 +143,10 @@ fun PostListings(
                     }
                 }
             }
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = SMALL_PADDING),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+            )
         }
 
         if (showPostAppendRetry) {


### PR DESCRIPTION
After a while I realized this looks better:

![Screenshot_2024-08-06-22-16-06-73_c9298fda48802cf3e2d17cb10a48759f](https://github.com/user-attachments/assets/35f59497-d8b2-41c7-82d0-ff696a7b87b2)
