### PR TITLE
Fixes wrong height Navigation bar when descriptions where hidden.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("UnstableApiUsage")
 
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
+
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -97,7 +100,7 @@ android {
 }
 
 composeCompiler {
-    enableStrongSkippingMode = true
+    featureFlags = setOf(ComposeFeatureFlag.StrongSkipping)
 }
 
 baselineProfile {

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -135,11 +135,10 @@ fun BottomAppBarAll(
             }
         }
     }
-// TODO check if this is needed
     // If descriptions are hidden, make the bar shorter
-//    val modifier = if (showTextDescriptionsInNavbar) Modifier else Modifier.height(56.dp)
+    val modifier = if (showTextDescriptionsInNavbar) Modifier else Modifier.navigationBarsPadding().height(56.dp)
     NavigationBar(
-        modifier = Modifier,
+        modifier = modifier,
     ) {
         for (tab in NavTab.getEntries(userViewType)) {
             val selected = tab == selectedTab

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -135,11 +135,11 @@ fun BottomAppBarAll(
             }
         }
     }
-
+// TODO check if this is needed
     // If descriptions are hidden, make the bar shorter
-    val modifier = if (showTextDescriptionsInNavbar) Modifier else Modifier.height(56.dp)
+//    val modifier = if (showTextDescriptionsInNavbar) Modifier else Modifier.height(56.dp)
     NavigationBar(
-        modifier = modifier,
+        modifier = Modifier,
     ) {
         for (tab in NavTab.getEntries(userViewType)) {
             val selected = tab == selectedTab


### PR DESCRIPTION
Since we switched to edgeToEdge. The height now starts from the bottom. (Before the System navigation bar instead of after) This small tweak makes it apply like before.

Fixes #1648

![image](https://github.com/user-attachments/assets/3639a7fd-f5e9-4161-8831-b2a5d9bca986)
