### PR TITLE
Fixes mostly systembars colors not matching with application

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -128,7 +128,7 @@ fun BottomAppBarAll(
         val colorScheme = MaterialTheme.colorScheme
 
         DisposableEffect(Unit) {
-            window.navigationBarColor = colorScheme.surfaceColorAtElevation(3.dp).toArgb()
+            window.navigationBarColor = colorScheme.surfaceContainer.toArgb()
 
             onDispose {
                 window.navigationBarColor = colorScheme.background.toArgb()

--- a/app/src/main/java/com/jerboa/ui/theme/Theme.kt
+++ b/app/src/main/java/com/jerboa/ui/theme/Theme.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.graphics.ColorUtils
+import androidx.core.view.WindowCompat
 import com.jerboa.ThemeColor
 import com.jerboa.ThemeMode
 import com.jerboa.db.entity.AppSettings
@@ -107,11 +109,25 @@ fun JerboaTheme(
 
     val view = LocalView.current
     val window = (view.context as Activity).window
+    val insets = WindowCompat.getInsetsController(window, view)
+
+    val isLight =
+        when (themeMode) {
+            ThemeMode.Black, ThemeMode.Dark -> false
+            ThemeMode.System, ThemeMode.SystemBlack -> !isSystemInDarkTheme()
+            else -> true
+        }
+
     if (appSettings.secureWindow) {
         window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
     } else {
         window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
     }
+
+    // The navigation bar color is set on BottomAppBarAll
+    insets.isAppearanceLightStatusBars = isLight
+    insets.isAppearanceLightNavigationBars = isLight
+    window.statusBarColor = Color.Transparent.toArgb()
 
     // Set up a provider to allow access to the custom color scheme from any child element
     CompositionLocalProvider(LocalColorScheme provides colors) {


### PR DESCRIPTION
The statusbar is not as perfect as before as it would change with the elevation color change, now not anymore.

These changes are needed:

```
insets.isAppearanceLightStatusBars = isLight
insets.isAppearanceLightNavigationBars = isLight
```

This is needed so that if you don't have system set as ThemeMode it will still set the correct (inverse) coloring of the statusbar.    

```
window.statusBarColor = Color.Transparent.toArgb()
```

Needed to mimic translucentStatus. Not as good but pretty close. see #1607 removal

The navigationbar seemed to use a different container color now. So this solves that.

![image](https://github.com/user-attachments/assets/a3bbdd58-0b24-42e2-8398-49ada14fd496)




#1649 