### PR TITLE
Fix 'Swipe right to navigate back' to go back multiple times

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/SwipeToNavigateBack.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/SwipeToNavigateBack.kt
@@ -18,20 +18,19 @@ fun SwipeToNavigateBack(
     content: @Composable () -> Unit,
 ) {
     if (useSwipeBack == PostNavigationGestureMode.SwipeRight) {
-        SwipeToDismissBox(
-            state = rememberSwipeToDismissBoxState(
-                confirmValueChange = {
-                    when (it) {
-                        SwipeToDismissBoxValue.StartToEnd -> {
-                            onSwipeBack()
-                            true
-                        }
+        val swipeState = rememberSwipeToDismissBoxState()
 
-                        else -> false
-                    }
-                },
-                positionalThreshold = { it * 0.7f },
-            ),
+        when (swipeState.currentValue) {
+            SwipeToDismissBoxValue.StartToEnd -> {
+                onSwipeBack()
+            }
+
+            else -> {
+            }
+        }
+
+        SwipeToDismissBox(
+            state = swipeState,
             enableDismissFromEndToStart = false,
             backgroundContent = {
                 Box(


### PR DESCRIPTION
Fixes #1653 

This was wrongly implemented, they hooked into the confirmation callback but this fires multiple times.

I used the actual state now.