### PR TITLE
Running renovate every weekend.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["before 4am on Monday"],
+  "schedule": ["every weekend"],
   "automerge": true
 }


### PR DESCRIPTION
Renovate rate limits itself, so it couldn't always finish up the rest of the updates. This gives it a larger window, without spamming notifications during the week.