### PR TITLE
Fixing bug with torrent magnet link posts.

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -1478,7 +1478,7 @@ fun String.toHttps(): String =
     }
 
 fun String.padUrlWithHttps(): String =
-    if (this.contains("://") || this.isBlank()) {
+    if (this.contains("://") || this.isBlank() || this.startsWith("magnet")) {
         this
     } else {
         "https://$this"

--- a/app/src/test/java/com/jerboa/UtilsKtTest.kt
+++ b/app/src/test/java/com/jerboa/UtilsKtTest.kt
@@ -27,7 +27,11 @@ import java.time.Instant
 import java.util.Date
 import java.util.Locale
 
-private const val MAGNET_LINK = "magnet:?xt=urn:btih:7ae3a882005bb337885f27610475543834642867&dn=Lenin%20-%20Socialism%20and%20Anarchism%20%5Baudiobook%5D%20by%20dessalines&tr=udp%3A%2F%2Ftracker.theoks.net%3A6969%2Fannounce"
+private const val MAGNET_LINK =
+    "magnet:?xt=urn:btih:7ae3a882005bb337885f27610475543834642867" +
+        "&dn=Lenin%20-%20Socialism%20and%20Anarchism%20%5Baudiobook" +
+        "%5D%20by%20dessalines" +
+        "&tr=udp%3A%2F%2Ftracker.theoks.net%3A6969%2Fannounce"
 
 @RunWith(JUnitParamsRunner::class)
 class UtilsKtTest {

--- a/app/src/test/java/com/jerboa/UtilsKtTest.kt
+++ b/app/src/test/java/com/jerboa/UtilsKtTest.kt
@@ -27,6 +27,8 @@ import java.time.Instant
 import java.util.Date
 import java.util.Locale
 
+private const val MAGNET_LINK = "magnet:?xt=urn:btih:7ae3a882005bb337885f27610475543834642867&dn=Lenin%20-%20Socialism%20and%20Anarchism%20%5Baudiobook%5D%20by%20dessalines&tr=udp%3A%2F%2Ftracker.theoks.net%3A6969%2Fannounce"
+
 @RunWith(JUnitParamsRunner::class)
 class UtilsKtTest {
     @JvmField
@@ -132,6 +134,7 @@ class UtilsKtTest {
 
         assertFalse(validateUrl(ctx, "").hasError)
         assertFalse(validateUrl(ctx, "https://example.com").hasError)
+        assertFalse(validateUrl(ctx, MAGNET_LINK).hasError)
         assertSame("url", validateUrl(ctx, "https://example.com").label)
     }
 
@@ -302,6 +305,7 @@ class UtilsKtTest {
         assertEquals("http://example.com", "http://example.com".padUrlWithHttps())
         assertEquals("https://example.com", "https://example.com".padUrlWithHttps())
         assertEquals("ws://example.com", "ws://example.com".padUrlWithHttps())
+        assertEquals(MAGNET_LINK, MAGNET_LINK.padUrlWithHttps())
         assertEquals("", "".padUrlWithHttps())
     }
 }


### PR DESCRIPTION
The `padUrlWithHttps` function broke magnet link posts.