### PR TITLE
Fixes: Webp images using image_proxy can't be saved in Android 10+

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -864,10 +864,16 @@ fun saveMediaQ(
     displayName: String,
     mediaType: PostType,
 ): Uri {
+    val mimeTypeWithFallback = mimeType ?: when (mediaType) {
+        PostType.Image -> "image/jpeg"
+        PostType.Video -> "video/mp4"
+        PostType.Link -> "application/octet-stream"
+    }
+
     val values =
         ContentValues().apply {
             put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
-            put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
+            put(MediaStore.MediaColumns.MIME_TYPE, mimeTypeWithFallback)
             put(MediaStore.MediaColumns.RELATIVE_PATH, mediaType.toMediaDir() + "/Jerboa")
         }
 

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -866,7 +866,7 @@ fun saveMediaQ(
 ): Uri {
     val mimeTypeWithFallback = mimeType ?: when (mediaType) {
         PostType.Image -> "image/jpeg"
-        PostType.Video -> "video/mp4"
+        PostType.Video -> "video/mpeg"
         PostType.Link -> null
     }
 

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -867,7 +867,7 @@ fun saveMediaQ(
     val mimeTypeWithFallback = mimeType ?: when (mediaType) {
         PostType.Image -> "image/jpeg"
         PostType.Video -> "video/mp4"
-        PostType.Link -> "application/octet-stream"
+        PostType.Link -> null
     }
 
     val values =

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     // This code creates the gradle managed device used to generate baseline profiles.
     // To use GMD please invoke generation through the command line:
     // ./gradlew :app:generateBaselineProfile
-    testOptions.managedDevices.devices {
+    testOptions.managedDevices.allDevices {
         create<ManagedVirtualDevice>("pixel6Api34") {
             device = "Pixel 6"
             apiLevel = 34


### PR DESCRIPTION
Worked on API Level 28 and below, uses a different API.

It fails to read MIME type from url. Normally thats fine, it will infer later when it gets inserted. For most images that okay, but it seems for webp images (or atleast those from pictrs) it infers the mime as "application/octet-stream" and then it throws exception because `Images.Media.EXTERNAL_CONTENT_URI` doesn't allow that MIME to be inserted there.

I looked at what some other clients do, some dont set MIME at all, meaning those images would also fail. Some always set `image/jpeg`. I added fallback for that here.

Not sure what the future holds for image_proxy endpoint? If kept we might want to better support it, properly extract extension and filename from it.

Fixes #1800 

allDevices was fix for deprecation (just rename)

---
This whole file handling is quite messy in Android. Basically forced to give wrong MIME.