### PR TITLE
Add Android 15 SDK support, Configure Android lint, deprecation fixes

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -29,6 +29,16 @@ steps:
     when:
       - event: pull_request
 
+  check_android_lint:
+    image: *android_image
+    commands:
+      - sudo chown -R circleci:circleci .
+      - ./gradlew lint
+    environment:
+      GRADLE_USER_HOME: ".gradle"
+    when:
+      - event: pull_request
+
   run_tests:
     image: *android_image
     commands:

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,4 +1,4 @@
-# Compose resources
+# Resources
 
 - [Architecture](https://developer.android.com/develop/ui/compose/architecture#udf)
 - [Compose coding design](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-api-guidelines.md#prefer-stateless-and-controlled-composable-functions)
@@ -9,3 +9,4 @@
 - [Material Design 3 docs](https://m3.material.io/)
 - [Jetpack Compose app Reply from compose-samples](https://github.com/android/compose-samples/tree/main/Reply)
 - [Design for android](https://developer.android.com/design/ui)
+- [Android Lint](https://developer.android.com/studio/write/lint)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,9 +30,12 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-        ksp {
-            arg("room.schemaLocation", "$projectDir/schemas")
-        }
+    }
+
+    lint {
+        disable += "MissingTranslation"
+        disable += "KtxExtensionAvailable"
+        disable += "UseKtx"
     }
 
     // Necessary for f-droid builds
@@ -94,6 +97,10 @@ android {
     buildFeatures {
         compose = true
     }
+}
+
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 baselineProfile {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,13 +16,13 @@ plugins {
 apply(from = "update_instances.gradle.kts")
 
 android {
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.jerboa"
         namespace = "com.jerboa"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 77
         versionName = "0.0.77"
 
@@ -113,12 +113,8 @@ dependencies {
     // Exporting / importing DB helper
     implementation("com.github.dessalines:room-db-export-import:0.1.0")
 
-    // Unfortunately, ui tooling, and the markdown thing, still brings in the other material2 dependencies
-    // This is the "official" composeBom, but it breaks the imageviewer until 1.7 is released. See:
-    // https://github.com/LemmyNet/jerboa/pull/1502#issuecomment-2137935525
-    // val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
+    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
 
-    val composeBom = platform("dev.chrisbanes.compose:compose-bom:2024.08.00-alpha02")
     api(composeBom)
     implementation("androidx.activity:activity-ktx")
     implementation("androidx.activity:activity-compose")
@@ -181,7 +177,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
 
     implementation("org.ocpsoft.prettytime:prettytime:5.0.9.Final")
-    implementation("androidx.navigation:navigation-compose:2.8.9")
+    implementation("androidx.navigation:navigation-compose:2.9.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
 
     testImplementation("junit:junit:4.13.2")

--- a/app/src/debug/res/values-ru/strings.xml
+++ b/app/src/debug/res/values-ru/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="app_name">Jerboa (ОТЛАДКА)</string>
-</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
                 <data android:mimeType="image/*" />
             </intent-filter>
 
-            <intent-filter>
+            <intent-filter android:autoVerify="false">
               <action android:name="android.intent.action.VIEW" />
               <category android:name="android.intent.category.DEFAULT" />
               <category android:name="android.intent.category.BROWSABLE" />

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -816,7 +816,7 @@ fun getCommentParentId(comment: Comment): CommentId? = getCommentParentId(commen
 fun getCommentParentId(commentPath: String): CommentId? {
     val split = commentPath.split(".").toMutableList()
     // remove the 0
-    split.removeFirst()
+    split.removeAt(0)
     return if (split.size > 1) {
         split[split.size - 2].toLong()
     } else {
@@ -1175,8 +1175,7 @@ fun copyToClipboard(
 ): Boolean {
     val activity = context.findActivity()
     activity?.let {
-        val clipboard: ClipboardManager =
-            it.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clipboard: ClipboardManager = it.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clip = ClipData.newPlainText(clipLabel, textToCopy)
         clipboard.setPrimaryClip(clip)
         return true

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentOptionsDropdown.kt
@@ -19,11 +19,9 @@ import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.AnnotatedString
 import com.jerboa.R
 import com.jerboa.api.API
 import com.jerboa.copyToClipboard
@@ -60,7 +58,6 @@ fun CommentOptionsDropdown(
     amAdmin: Boolean,
     viewSource: Boolean,
 ) {
-    val localClipboardManager = LocalClipboardManager.current
     val ctx = LocalContext.current
 
     CascadeCenteredDropdownMenu(
@@ -95,13 +92,22 @@ fun CommentOptionsDropdown(
                 onClick = {
                     onDismissRequest()
                     val permalink = commentView.comment.ap_id
-                    localClipboardManager.setText(AnnotatedString(permalink))
-                    Toast
-                        .makeText(
-                            ctx,
-                            ctx.getString(R.string.comment_node_permalink_copied),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+
+                    if (copyToClipboard(ctx, permalink, "Permalink")) {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.comment_node_permalink_copied),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    } else {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.generic_error),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }
                 },
             )
             val content = commentView.comment.getContent()

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionOptionsDropdown.kt
@@ -14,10 +14,8 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Restore
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import com.jerboa.R
 import com.jerboa.copyToClipboard
 import com.jerboa.datatypes.getContent
@@ -41,7 +39,6 @@ fun CommentMentionsOptionsDropdown(
     canMod: Boolean,
     viewSource: Boolean,
 ) {
-    val localClipboardManager = LocalClipboardManager.current
     val ctx = LocalContext.current
 
     CascadeCenteredDropdownMenu(
@@ -76,13 +73,22 @@ fun CommentMentionsOptionsDropdown(
                 onClick = {
                     onDismissRequest()
                     val permalink = personMentionView.comment.ap_id
-                    localClipboardManager.setText(AnnotatedString(permalink))
-                    Toast
-                        .makeText(
-                            ctx,
-                            ctx.getString(R.string.comment_node_permalink_copied),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+
+                    if (copyToClipboard(ctx, permalink, "Permalink")) {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.comment_node_permalink_copied),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    } else {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.generic_error),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }
                 },
             )
             val content = personMentionView.comment.getContent()

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyOptionsDropdown.kt
@@ -12,10 +12,8 @@ import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import com.jerboa.R
 import com.jerboa.copyToClipboard
 import com.jerboa.datatypes.getContent
@@ -37,7 +35,6 @@ fun CommentReplyOptionsDropdown(
     isCreator: Boolean,
     viewSource: Boolean,
 ) {
-    val localClipboardManager = LocalClipboardManager.current
     val ctx = LocalContext.current
 
     CascadeCenteredDropdownMenu(
@@ -72,13 +69,22 @@ fun CommentReplyOptionsDropdown(
                 onClick = {
                     onDismissRequest()
                     val permalink = commentReplyView.comment.ap_id
-                    localClipboardManager.setText(AnnotatedString(permalink))
-                    Toast
-                        .makeText(
-                            ctx,
-                            ctx.getString(R.string.comment_node_permalink_copied),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+
+                    if (copyToClipboard(ctx, permalink, "Permalink")) {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.comment_node_permalink_copied),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    } else {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.generic_error),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }
                 },
             )
             val content = commentReplyView.comment.getContent()

--- a/app/src/main/java/com/jerboa/ui/components/common/LinkDropDownMenu.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/LinkDropDownMenu.kt
@@ -13,10 +13,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.jerboa.JerboaAppState
 import com.jerboa.PostType
 import com.jerboa.R
+import com.jerboa.copyToClipboard
 import com.jerboa.feat.shareLink
 import com.jerboa.feat.shareMedia
 import com.jerboa.feat.storeMedia
@@ -39,7 +38,6 @@ fun LinkDropDownMenu(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
 ) {
-    val localClipboardManager = LocalClipboardManager.current
     val ctx = LocalContext.current
 
     if (link != null) {
@@ -86,13 +84,21 @@ fun LinkDropDownMenu(
                 icon = Icons.Outlined.Link,
                 onClick = {
                     onDismissRequest()
-                    localClipboardManager.setText(AnnotatedString(link))
-                    Toast
-                        .makeText(
-                            ctx,
-                            ctx.getString(R.string.post_listing_link_copied),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                    if (copyToClipboard(ctx, link, "Link")) {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.post_listing_link_copied),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    } else {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.generic_error),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }
                 },
             )
 

--- a/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
@@ -3,28 +3,26 @@ package com.jerboa.ui.components.common
 import android.os.Build
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.Autofill
-import androidx.compose.ui.autofill.AutofillNode
-import androidx.compose.ui.autofill.AutofillTree
-import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 
 inline fun Modifier.ifDo(
     predicate: Boolean,
     modifier: Modifier.() -> Modifier,
 ): Modifier = if (predicate) modifier() else this
+
+inline fun <T> Modifier.ifNotNull(
+    value: T?,
+    modifier: Modifier.(_: T) -> Modifier,
+): Modifier = if (value != null) modifier(value) else this
+
 
 fun Modifier.getBlurredOrRounded(
     blur: Boolean,
@@ -39,34 +37,6 @@ fun Modifier.getBlurredOrRounded(
         lModifier = lModifier.blur(radius = 100.dp)
     }
     return lModifier
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-fun Modifier.onAutofill(
-    tree: AutofillTree,
-    autofill: Autofill?,
-    autofillTypes: List<AutofillType>,
-    onFill: (String) -> Unit,
-): Modifier {
-    val autofillNode =
-        AutofillNode(
-            autofillTypes = autofillTypes,
-            onFill = onFill,
-        )
-    tree += autofillNode
-
-    return this
-        .onGloballyPositioned {
-            autofillNode.boundingBox = it.boundsInWindow()
-        }.onFocusChanged { focusState ->
-            autofill?.run {
-                if (focusState.isFocused) {
-                    requestAutofillForNode(autofillNode)
-                } else {
-                    cancelAutofillForNode(autofillNode)
-                }
-            }
-        }
 }
 
 fun Modifier.customMarquee(): Modifier = this.basicMarquee(initialDelayMillis = 4_000)

--- a/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
@@ -23,7 +23,6 @@ inline fun <T> Modifier.ifNotNull(
     modifier: Modifier.(_: T) -> Modifier,
 ): Modifier = if (value != null) modifier(value) else this
 
-
 fun Modifier.getBlurredOrRounded(
     blur: Boolean,
     rounded: Boolean = false,

--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -77,8 +77,8 @@ fun MyTextField(
         modifier = modifier
             .width(OutlinedTextFieldDefaults.MinWidth)
             .ifNotNull(autofillContentType) {
-                this.semantics { contentType = it}
-            }
+                this.semantics { contentType = it }
+            },
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/post/composables/PostOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/composables/PostOptionsDropdown.kt
@@ -25,11 +25,9 @@ import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.AnnotatedString
 import com.jerboa.PostType
 import com.jerboa.R
 import com.jerboa.api.API.getInstanceOrNull
@@ -89,7 +87,6 @@ fun PostOptionsDropdown(
 ) {
     val ctx = LocalContext.current
     val api = getInstanceOrNull()
-    val localClipboardManager = LocalClipboardManager.current
     val (featureIcon, unFeatureIcon) = Pair(Icons.Outlined.PushPin, Icons.Outlined.CancelPresentation)
 
     CascadeCenteredDropdownMenu(
@@ -128,13 +125,22 @@ fun PostOptionsDropdown(
                     icon = Icons.Outlined.Link,
                     onClick = {
                         onDismissRequest()
-                        localClipboardManager.setText(AnnotatedString(it))
-                        Toast
-                            .makeText(
-                                ctx,
-                                ctx.getString(R.string.post_listing_link_copied),
-                                Toast.LENGTH_SHORT,
-                            ).show()
+
+                        if (copyToClipboard(ctx, it, "Link")) {
+                            Toast
+                                .makeText(
+                                    ctx,
+                                    ctx.getString(R.string.post_listing_link_copied),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                        } else {
+                            Toast
+                                .makeText(
+                                    ctx,
+                                    ctx.getString(R.string.generic_error),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                        }
                     },
                 )
             }
@@ -145,13 +151,22 @@ fun PostOptionsDropdown(
                 onClick = {
                     onDismissRequest()
                     val permalink = postView.post.ap_id
-                    localClipboardManager.setText(AnnotatedString(permalink))
-                    Toast
-                        .makeText(
-                            ctx,
-                            ctx.getString(R.string.post_listing_permalink_copied),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+
+                    if (copyToClipboard(ctx, permalink, "Permalink")) {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.post_listing_permalink_copied),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    } else {
+                        Toast
+                            .makeText(
+                                ctx,
+                                ctx.getString(R.string.generic_error),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }
                 },
             )
 

--- a/app/src/main/java/com/jerboa/ui/components/settings/about/AboutScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/about/AboutScreen.kt
@@ -283,7 +283,7 @@ fun AboutPreview() {
 
 fun getInstallCode(compilationStatus: CompilationStatus): String =
     when (compilationStatus.profileInstallResultCode) {
-        CompilationStatus.RESULT_CODE_NO_PROFILE -> "NO_PROFILE"
+        CompilationStatus.RESULT_CODE_NO_PROFILE_INSTALLED -> "NO_PROFILE_INSTALLED"
         CompilationStatus.RESULT_CODE_COMPILED_WITH_PROFILE -> "COMPILED_WITH_PROFILE"
         CompilationStatus.RESULT_CODE_PROFILE_ENQUEUED_FOR_COMPILATION -> "PROFILE_ENQUEUED_FOR_COMPILATION"
         CompilationStatus.RESULT_CODE_ERROR_UNSUPPORTED_API_VERSION -> "ERROR_UNSUPPORTED_API_VERSION"

--- a/app/src/main/java/com/jerboa/util/BlurTransformation.kt
+++ b/app/src/main/java/com/jerboa/util/BlurTransformation.kt
@@ -58,7 +58,7 @@ private suspend fun Bitmap.blur(
         val width = (sentBitmap.width * scale).roundToInt()
         val height = (sentBitmap.height * scale).roundToInt()
         sentBitmap = Bitmap.createScaledBitmap(sentBitmap, width, height, false)
-        val bitmap = sentBitmap.copy(sentBitmap.config, true)
+        val bitmap = sentBitmap.copy(sentBitmap.config ?: return@withContext null, true)
         if (radius < 1) {
             return@withContext null
         }

--- a/app/src/main/java/com/jerboa/util/markwon/ClickableCoilImagesPlugin.kt
+++ b/app/src/main/java/com/jerboa/util/markwon/ClickableCoilImagesPlugin.kt
@@ -77,7 +77,7 @@ internal class ClickableImageFactory(
                 }
             }
 
-        return arrayOf(image, clickSpan)
+        return arrayOf<Any>(image, clickSpan)
     }
 }
 

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -30,8 +30,6 @@
     <string name="account_settings_show_scores">Показване на точки</string>
     <string name="account_settings_subscribed">Абонаменти</string>
     <string name="addBookmark">Добавяне към отметките</string>
-    <string name="app_bars_dot_spacer" translatable="false">·</string>
-    <string name="app_name" translatable="false">Jerboa</string>
     <string name="bottomBar_bookmarks">Към моите отметки</string>
     <string name="bottomBar_home">Към началото</string>
     <string name="bottomBar_inbox">Към входящи</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -287,7 +287,6 @@
     <string name="title_min_3_chars">Заглавието трябва да е дълго поне 3 знака</string>
     <string name="title_required">Заглавието е задължително</string>
     <string name="topAppBar_back">Назад</string>
-    <string name="url" translatable="false">URL</string>
     <string name="url_invalid">Невалиден URL</string>
     <string name="utils_login_first">Първо влезте</string>
     <string name="upvote">Глас нагоре</string>
@@ -393,7 +392,6 @@
     <string name="posts_failed_loading">Неуспешно зареждане на публикации, опитайте отново</string>
     <string name="failed_sharing_media">Неуспешно споделяне на мултимедия!</string>
     <string name="app_settings_nothing">Нищо</string>
-    <string name="app_settings_blur_nsfw" translatable="false">NSFW</string>
     <string name="app_settings_blur_nsfw_except_from_nsfw_communities">NSFW освен от NSFW общности</string>
     <string name="app_settings_blur_nsfw_except_from_nsfw_inside_community">Освен NSFW в общност</string>
     <string name="time_ago_failed_to_parse">Неуспешно анализиране на дата и час</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -30,8 +30,6 @@
     <string name="account_settings_show_scores">Puanları Göster</string>
     <string name="account_settings_subscribed">Abone Olunan</string>
     <string name="addBookmark">Yer imlerine ekle</string>
-    <string name="app_bars_dot_spacer" translatable="false">·</string>
-    <string name="app_name" translatable="false">Jerboa</string>
     <string name="bottomBar_bookmarks">Yer imlerime git</string>
     <string name="bottomBar_home">Ana sayfaya git</string>
     <string name="bottomBar_inbox">Gelen kutuma git</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -290,7 +290,6 @@
     <string name="title_min_3_chars">Başlık en az üç karakter olmalıdır</string>
     <string name="title_required">Başlık gerekli</string>
     <string name="topAppBar_back">Geri</string>
-    <string name="url" translatable="false">URL</string>
     <string name="url_invalid">Geçersiz URL</string>
     <string name="utils_login_first">Önce giriş yapın</string>
     <string name="upvote">Yukarı oy ver</string>
@@ -396,7 +395,6 @@
     <string name="posts_failed_loading">Gönderiler yüklenemedi, yeniden dene</string>
     <string name="failed_sharing_media">Medya paylaşılamadı!</string>
     <string name="app_settings_nothing">Hiçbiri</string>
-    <string name="app_settings_blur_nsfw" translatable="false">NSFW</string>
     <string name="app_settings_blur_nsfw_except_from_nsfw_communities">NSFW topluluklarından gelenler hariç NSFW</string>
     <string name="app_settings_blur_nsfw_except_from_nsfw_inside_community">Topluluk içindeki NSFW hariç</string>
     <string name="time_ago_failed_to_parse">Tarih saat ayrıştırılamadı</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="AppBars_comments">%1$s 条评论</string>
     <string name="AppBars_created">已创建</string>
     <string name="AppBars_posts">%1$s 帖文</string>
@@ -406,14 +405,14 @@
     <string name="only_left_swipe_action_preset">只向左滑动</string>
     <string name="person_banned">禁止 %1$s</string>
     <string name="person_banned_for_x_days">禁止 %1$s %2$d 天</string>
-    <string name="person_banned_from_community">从 %2$d 禁止 %1$s</string>
-    <string name="person_banned_from_community_for_x_days">从 %2$d 禁止 %1$s %2$d 天</string>
+    <string name="person_banned_from_community">从 %2$s 禁止 %1$s</string>
+    <string name="person_banned_from_community_for_x_days">从 %2$s 禁止 %1$s %3$d 天</string>
     <string name="person_unbanned">已解禁 %1$s</string>
-    <string name="person_unbanned_from_community">从 %2$d 已解禁 %1$s</string>
+    <string name="person_unbanned_from_community">从 %2$s 已解禁 %1$s</string>
     <string name="ban_person">禁止 %1$s</string>
-    <string name="ban_person_from_community">从 %2$d 禁止 %1$s</string>
+    <string name="ban_person_from_community">从 %2$s 禁止 %1$s</string>
     <string name="unban_person">解禁 %1$s</string>
-    <string name="unban_person_from_community">从 %2$d 解禁 %1$s</string>
+    <string name="unban_person_from_community">从 %2$s 解禁 %1$s</string>
     <string name="remove_content">移除内容</string>
     <string name="permaban">永久封禁</string>
     <string name="days_until_expiration">到期前的天数</string>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -20,4 +20,5 @@
     <locale android:name="ar"/>
     <locale android:name="bg"/>
     <locale android:name="tr"/>
+    <locale android:name="zh"/>
 </locale-config>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.android.application") version "8.10.0" apply false
-    id("com.android.library") version "8.9.2" apply false
+    id("com.android.library") version "8.10.0" apply false
     id("org.jetbrains.kotlin.android") version "2.1.20" apply false
     id("org.jmailen.kotlinter") version "5.0.2" apply false
     id("com.google.devtools.ksp") version "2.1.20-2.0.1" apply false
-    id("com.android.test") version "8.9.2" apply false
+    id("com.android.test") version "8.10.0" apply false
     id("androidx.baselineprofile") version "1.3.4" apply false
 }
 


### PR DESCRIPTION
Discovered Android Lint recently, Its pretty handy. I discovered some issues with the translations with it. I have added it to the CI.

It generates a report like this.
![image](https://github.com/user-attachments/assets/9c773271-a7ab-4026-bde7-68cee8a030a2)

Also bump SDK to 35 and Compose Bom to 2025.05

Fixes LocalClipboardManager deprecations (new API)

Fixes autofill deprecations (new API)

the setColor for statusBar and navigationBar have been deprecated because in Android 15. Its fixed to some transparent mode.

So not sure yet how to handle this for pre android 15. Will check that out later.