### PR TITLE
Fixes #1748 Extra padding above IME keyboard

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/ban/BanPerson.kt
+++ b/app/src/main/java/com/jerboa/ui/components/ban/BanPerson.kt
@@ -2,7 +2,6 @@ package com.jerboa.ui.components.ban
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -48,7 +47,6 @@ fun BanPersonBody(
             text = reason,
             onTextChange = onReasonChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
             placeholder = stringResource(R.string.type_your_reason),
         )
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEdit.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEdit.kt
@@ -3,7 +3,7 @@ package com.jerboa.ui.components.comment.edit
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -30,13 +30,13 @@ fun CommentEdit(
             Modifier
                 .verticalScroll(scrollState)
                 .padding(padding)
+                .consumeWindowInsets(padding)
                 .imePadding(),
     ) {
         MarkdownTextField(
             text = content,
             onTextChange = onContentChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
             placeholder = stringResource(R.string.comment_edit_type_your_comment),
         )
     }

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
@@ -2,7 +2,6 @@
 package com.jerboa.ui.components.comment.reply
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -148,7 +147,6 @@ fun CommentReply(
             text = reply,
             onTextChange = onReplyChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -178,7 +176,6 @@ fun CommentReplyReply(
             text = reply,
             onTextChange = onReplyChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -208,7 +205,6 @@ fun MentionReply(
             text = reply,
             onTextChange = onReplyChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -238,7 +234,6 @@ fun PostReply(
             text = reply,
             onTextChange = onReplyChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
             placeholder = stringResource(R.string.comment_reply_type_your_comment),
         )
     }

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyScreen.kt
@@ -1,6 +1,7 @@
 package com.jerboa.ui.components.comment.reply
 
 import android.util.Log
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -48,10 +49,7 @@ fun CommentReplyScreen(
     val replyItem = appState.getPrevReturn<ReplyItem>(CommentReplyReturn.COMMENT_SEND)
 
     var reply by rememberSaveable(stateSaver = TextFieldValue.Saver) {
-        mutableStateOf(
-            TextFieldValue
-                (""),
-        )
+        mutableStateOf(TextFieldValue(""))
     }
 
     val focusManager = LocalFocusManager.current
@@ -101,6 +99,7 @@ fun CommentReplyScreen(
                             modifier =
                                 Modifier
                                     .padding(padding)
+                                    .consumeWindowInsets(padding)
                                     .imePadding(),
                             showAvatar = siteViewModel.showAvatar(),
                         )
@@ -116,6 +115,7 @@ fun CommentReplyScreen(
                             modifier =
                                 Modifier
                                     .padding(padding)
+                                    .consumeWindowInsets(padding)
                                     .imePadding(),
                         )
 
@@ -129,6 +129,7 @@ fun CommentReplyScreen(
                             modifier =
                                 Modifier
                                     .padding(padding)
+                                    .consumeWindowInsets(padding)
                                     .imePadding(),
                             showAvatar = siteViewModel.showAvatar(),
                         )
@@ -143,6 +144,7 @@ fun CommentReplyScreen(
                             modifier =
                                 Modifier
                                     .padding(padding)
+                                    .consumeWindowInsets(padding)
                                     .imePadding(),
                             showAvatar = siteViewModel.showAvatar(),
                         )

--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -115,7 +115,9 @@ fun MarkdownTextField(
                 value = text,
                 onValueChange = onTextChange,
                 label = { Text(text = placeholder) },
-                modifier = modifier.focusRequester(focusRequester),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
                 keyboardOptions =
                     KeyboardOptions.Default.copy(
                         capitalization = KeyboardCapitalization.Sentences,
@@ -128,7 +130,9 @@ fun MarkdownTextField(
                 value = text,
                 onValueChange = onTextChange,
                 placeholder = { Text(text = placeholder) },
-                modifier = modifier.focusRequester(focusRequester),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
                 keyboardOptions =
                     KeyboardOptions.Default.copy(
                         capitalization = KeyboardCapitalization.Sentences,

--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -218,10 +217,7 @@ fun LoginForm(
         )
 
     Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .imePadding(),
+        modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginScreen.kt
@@ -1,6 +1,7 @@
 package com.jerboa.ui.components.login
 
 import android.util.Log
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -48,6 +49,7 @@ fun LoginScreen(
                 modifier =
                     Modifier
                         .padding(padding)
+                        .consumeWindowInsets(padding)
                         .imePadding(),
                 onClickLogin = { form, instance ->
                     loginViewModel.login(

--- a/app/src/main/java/com/jerboa/ui/components/post/composables/PostComposables.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/composables/PostComposables.kt
@@ -208,7 +208,6 @@ fun CreateEditPostBody(
             account = account,
             focusImmediate = false,
             placeholder = stringResource(R.string.post_edit_body_placeholder),
-            modifier = Modifier.fillMaxWidth(),
         )
 
         /**

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/CreatePrivateMessageScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/CreatePrivateMessageScreen.kt
@@ -3,7 +3,7 @@ package com.jerboa.ui.components.privatemessage
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -108,13 +108,13 @@ fun CreatePrivateMessageScreen(
                     Modifier
                         .verticalScroll(scrollState)
                         .padding(padding)
+                        .consumeWindowInsets(padding)
                         .imePadding(),
             ) {
                 MarkdownTextField(
                     text = textBody,
                     onTextChange = { textBody = it },
                     account = account,
-                    modifier = Modifier.fillMaxWidth(),
                     placeholder = stringResource(R.string.private_message_placeholder),
                 )
             }

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReply.kt
@@ -2,7 +2,6 @@
 package com.jerboa.ui.components.privatemessage
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -77,7 +76,6 @@ fun PrivateMessageReply(
             text = reply,
             onTextChange = onReplyChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
             placeholder = stringResource(R.string.private_message_reply_type_your_message_placeholder),
         )
     }

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyScreen.kt
@@ -1,6 +1,7 @@
 package com.jerboa.ui.components.privatemessage
 
 import android.util.Log
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -94,6 +95,7 @@ fun PrivateMessageReplyScreen(
                         modifier =
                             Modifier
                                 .padding(padding)
+                                .consumeWindowInsets(padding)
                                 .imePadding(),
                         showAvatar = siteViewModel.showAvatar(),
                     )

--- a/app/src/main/java/com/jerboa/ui/components/registrationapplications/RegistrationApplications.kt
+++ b/app/src/main/java/com/jerboa/ui/components/registrationapplications/RegistrationApplications.kt
@@ -358,7 +358,6 @@ fun RegistrationApplicationItem(
                 text = denyReason,
                 onTextChange = { denyReason = it },
                 account = account,
-                modifier = Modifier.fillMaxWidth(),
                 placeholder = stringResource(R.string.type_your_reason),
             )
         }

--- a/app/src/main/java/com/jerboa/ui/components/remove/RemoveItem.kt
+++ b/app/src/main/java/com/jerboa/ui/components/remove/RemoveItem.kt
@@ -2,7 +2,7 @@ package com.jerboa.ui.components.remove
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -29,13 +29,13 @@ fun RemoveItemBody(
             Modifier
                 .verticalScroll(scrollState)
                 .padding(padding)
+                .consumeWindowInsets(padding)
                 .imePadding(),
     ) {
         MarkdownTextField(
             text = reason,
             onTextChange = onReasonChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
             placeholder = stringResource(R.string.type_your_reason),
         )
     }

--- a/app/src/main/java/com/jerboa/ui/components/report/CreateReport.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/CreateReport.kt
@@ -2,7 +2,7 @@ package com.jerboa.ui.components.report
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -29,13 +29,13 @@ fun CreateReportBody(
             Modifier
                 .verticalScroll(scrollState)
                 .padding(padding)
+                .consumeWindowInsets(padding)
                 .imePadding(),
     ) {
         MarkdownTextField(
             text = reason,
             onTextChange = onReasonChange,
             account = account,
-            modifier = Modifier.fillMaxWidth(),
             placeholder = stringResource(R.string.create_report_type_your_reason),
         )
     }

--- a/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -184,9 +185,10 @@ fun SettingsForm(
     Column(
         modifier =
             Modifier
+                .verticalScroll(rememberScrollState())
                 .padding(padding)
-                .imePadding()
-                .verticalScroll(rememberScrollState()),
+                .consumeWindowInsets(padding)
+                .imePadding(),
         verticalArrangement = Arrangement.spacedBy(MEDIUM_PADDING),
     ) {
         SettingsTextField(
@@ -204,9 +206,6 @@ fun SettingsForm(
                 account = account,
                 outlined = true,
                 focusImmediate = false,
-                modifier =
-                    Modifier
-                        .fillMaxWidth(),
             )
         }
 


### PR DESCRIPTION
The imePadding seemed to also apply the navigationBar padding. Using this `consumeWindowInsets` made it only apply once.

Also refactored `MarkdownTextField` slightly to not have that required maxFillSize default as part of params and apply the same modifier twice.