### PR TITLE
Fixes #1755 Keyboard still open after creating comment

### DIFF
--- a/app/src/main/java/com/jerboa/model/CommentReplyViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/CommentReplyViewModel.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.focus.FocusManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jerboa.api.API
@@ -52,7 +51,6 @@ class CommentReplyViewModel : ViewModel() {
         reply: ReplyItem,
         ctx: Context,
         content: String,
-        focusManager: FocusManager,
         onSuccess: (CommentView) -> Unit,
     ) {
         val (postId, commentParentId) =
@@ -90,7 +88,6 @@ class CommentReplyViewModel : ViewModel() {
                 is ApiState.Success -> {
                     val commentView = res.data.comment_view
 
-                    focusManager.clearFocus()
                     onSuccess(commentView)
                 }
                 is ApiState.Failure -> {

--- a/app/src/main/java/com/jerboa/model/PrivateMessageReplyViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/PrivateMessageReplyViewModel.kt
@@ -3,7 +3,6 @@ package com.jerboa.model
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.focus.FocusManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jerboa.api.API
@@ -22,7 +21,6 @@ class PrivateMessageReplyViewModel : ViewModel() {
         recipientId: PersonId,
         content: String,
         onGoBack: () -> Unit,
-        focusManager: FocusManager,
     ) {
         viewModelScope.launch {
             val form =
@@ -33,7 +31,6 @@ class PrivateMessageReplyViewModel : ViewModel() {
             createMessageRes = ApiState.Loading
             createMessageRes = API.getInstance().createPrivateMessage(form).toApiState()
 
-            focusManager.clearFocus()
             onGoBack()
         }
     }

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -54,10 +53,11 @@ fun CommentReplyScreen(
         )
     }
 
-    val focusManager = LocalFocusManager.current
     val loading =
         when (commentReplyViewModel.createCommentRes) {
-            ApiState.Loading -> true
+            // When comment is created, still show loading so that ReplyItem is not entered composition
+            // again for a brief period, thus requesting focus again and opening keyboard
+            ApiState.Loading, is ApiState.Success -> true
             else -> false
         }
 
@@ -73,7 +73,6 @@ fun CommentReplyScreen(
                             replyItem,
                             ctx = ctx,
                             content = reply.text,
-                            focusManager = focusManager,
                         ) { cv ->
                             appState.apply {
                                 addReturn(CommentReplyReturn.COMMENT_VIEW, cv)

--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -41,7 +41,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -161,11 +161,10 @@ fun MarkdownTextField(
         )
     }
 
-    DisposableEffect(Unit) {
-        if (focusImmediate) {
+    if (focusImmediate) {
+        LaunchedEffect(Unit) {
             focusRequester.requestFocus()
         }
-        onDispose { }
     }
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -52,11 +51,9 @@ fun PrivateMessageReplyScreen(
 
     var reply by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
 
-    val focusManager = LocalFocusManager.current
-
     val loading =
         when (privateMessageReplyViewModel.createMessageRes) {
-            ApiState.Loading -> true
+            ApiState.Loading, is ApiState.Success -> true
             else -> false
         }
 
@@ -72,7 +69,6 @@ fun PrivateMessageReplyScreen(
                                 recipientId = privateMessageView.creator.id,
                                 content = reply.text,
                                 onGoBack = onBack,
-                                focusManager,
                             )
                         }
                     },

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyScreen.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyScreen.kt
@@ -53,6 +53,8 @@ fun PrivateMessageReplyScreen(
 
     val loading =
         when (privateMessageReplyViewModel.createMessageRes) {
+            // When message is created, still show loading so that PrivateMessageView is not entered composition
+            // again for a brief period, thus requesting focus again and opening keyboard
             ApiState.Loading, is ApiState.Success -> true
             else -> false
         }


### PR DESCRIPTION
When sending the comment, it goes into "loading" mode, here the CommentReplyView leaves the composition, then when it receives response it goes into ApiState Success. Now the previous ReplyView enters composition again for short period. Where it asks for focus again. Thus the open keyboard state after creating a comment.

This fixes it by not showing the CommentReply view after sending. Thus it doesnt ask for focus.

Also removed the focus removal. It doesn't seem to do anything.


https://github.com/user-attachments/assets/345e0554-3d78-4007-aed0-fff8438af54f

The other screens aren't affected because they don't show a loading bar and hide the body. Thus it doesn't leave composition. :)


Fixes #1755 


