### PR TITLE
Fix edgecase saveImage failing causing crash

### DIFF
--- a/app/src/main/java/com/jerboa/feat/UserActions.kt
+++ b/app/src/main/java/com/jerboa/feat/UserActions.kt
@@ -100,6 +100,9 @@ private suspend fun saveMedia(
     } catch (e: IllegalArgumentException) {
         Log.d("saveMedia", "invalid URL", e)
         Toast.makeText(context, R.string.failed_saving_media, Toast.LENGTH_SHORT).show()
+    } catch (e: Exception) {
+        Log.d("saveMedia", "unexpected error", e)
+        Toast.makeText(context, R.string.failed_saving_media, Toast.LENGTH_SHORT).show()
     }
 }
 
@@ -147,10 +150,10 @@ fun shareMedia(
 
         ctx.startActivitySafe(Intent.createChooser(shareIntent, ctx.getString(R.string.share)))
     } catch (e: IOException) {
-        Log.d("shareMedia", "failed", e)
+        Log.d("shareMedia", "io failed", e)
         Toast.makeText(ctx, R.string.failed_sharing_media, Toast.LENGTH_SHORT).show()
     } catch (e: Exception) {
-        Log.d("shareMedia", "invalid URL", e)
+        Log.d("shareMedia", "failed", e)
         Toast.makeText(ctx, R.string.failed_sharing_media, Toast.LENGTH_SHORT).show()
     }
 }
@@ -238,7 +241,7 @@ fun copyImageToClipboard(
         Log.d("copyMedia", "io failed", e)
         Toast.makeText(ctx, R.string.failed_copy_media, Toast.LENGTH_SHORT).show()
     } catch (e: Exception) {
-        Log.d("copyMedia", "invalid URL", e)
+        Log.d("copyMedia", "failed", e)
         Toast.makeText(ctx, R.string.failed_copy_media, Toast.LENGTH_SHORT).show()
     }
 }


### PR DESCRIPTION
A failure like this below in `saveMedia` action would cause the app to crash. Due to missing catch. I checked some other actions they seem good.

> java.lang.IllegalStateException: Failed to build unique file: /storage/emulated/0/Pictures/Jerboa image_proxy

Now the failure itself. Apparently you can only have like 32 duplicate filenames before it starts throwing that failure. For 

See screenshots below (This could be selective to only a few Android versions)

![image](https://github.com/user-attachments/assets/524f6f59-3067-4876-8e01-82c2731b1932)

![image](https://github.com/user-attachments/assets/42c65da4-0418-47e3-b40c-27dc6542796f)

This was found because it would save all image_proxy images as "image_proxy" likely would not have been encountered else. But if we do seem to be encountering this elseware and it not being a specific android version specific. We could look into preventing this failure. (Randomized hash as filename or looking up how some other apps might deal with this)