### PR TITLE
Fix LemmyAPI build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 
 plugins {
@@ -14,6 +15,14 @@ plugins {
 }
 
 apply(from = "update_instances.gradle.kts")
+
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget("17")
+        freeCompilerArgs = listOf("-Xjvm-default=all-compatibility", "-opt-in=kotlin.RequiresOptIn")
+    }
+}
 
 android {
     compileSdk = 35
@@ -89,10 +98,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-        freeCompilerArgs = listOf("-Xjvm-default=all-compatibility", "-opt-in=kotlin.RequiresOptIn")
     }
     buildFeatures {
         compose = true
@@ -192,7 +197,7 @@ dependencies {
     implementation("androidx.profileinstaller:profileinstaller")
     baselineProfile(project(":benchmarks"))
 
-    implementation("it.vercruysse.lemmyapi:lemmy-api:0.4.1-SNAPSHOT")
+    implementation("it.vercruysse.lemmyapi:lemmy-api:0.4.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 
     // For custom logging plugin

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -23,9 +23,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-
-    }
 
     defaultConfig {
         testInstrumentationRunnerArguments += mapOf("suppressErrors" to "EMULATOR")

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,10 +1,18 @@
 @file:Suppress("UnstableApiUsage")
 import com.android.build.api.dsl.ManagedVirtualDevice
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.test")
     id("org.jetbrains.kotlin.android")
     id("androidx.baselineprofile")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget("17")
+        freeCompilerArgs = listOf("-Xjvm-default=all-compatibility", "-opt-in=kotlin.RequiresOptIn")
+    }
 }
 
 android {
@@ -16,8 +24,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "17"
-        freeCompilerArgs = listOf("-Xjvm-default=all-compatibility", "-opt-in=kotlin.RequiresOptIn")
+
     }
 
     defaultConfig {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,8 +11,6 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
-        // For Snapshots of LemmyAPI
-        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
     }
 }
 rootProject.name = "jerboa"


### PR DESCRIPTION
LemmyAPI was published to OSSHR but that got sunset. And all my SNAPSHOT deployments got removed.
see  https://central.sonatype.org/pages/ossrh-eol/

So i have published it to mavencentral now.

Also fixed some deprecations regarding gradle DSL see https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-from-kotlinoptions-to-compileroptions