### PR TITLE
Fix crashes on Android 9 due to compose bump

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,3 +33,8 @@
 
 # Ktor needs this
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+
+# Until https://issuetracker.google.com/issues/425120571 is fixed
+-keepclassmembers class androidx.compose.ui.graphics.layer.view.ViewLayerContainer {
+    protected void dispatchGetDisplayList();
+}


### PR DESCRIPTION
From https://issuetracker.google.com/issues/425120571

It seems they forgot to readd a proguard rule.

This should fix the crashes on Android 9

Fixes #1849