### PR TITLE
Restore deprecated apk post processing config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,7 +82,14 @@ android {
                 signingConfig = signingConfigs.getByName("release")
             }
 
-            proguardFiles("proguard-rules.pro")
+            // Keep using until AGP 9.0 then research proguard rules to retain debug info for stack traces
+            postprocessing {
+                isRemoveUnusedCode = true
+                isObfuscate = false
+                isOptimizeCode = true
+                isRemoveUnusedResources = true
+                proguardFiles("proguard-rules.pro")
+            }
         }
         debug {
             applicationIdSuffix = ".debug"


### PR DESCRIPTION
I did some testing and reading, by default R8 isn't on. Unless you specify `isMinifyEnabled `

see https://developer.android.com/topic/performance/app-optimization/enable-app-optimization

APK results

```
-rwxrwxrwx 1 maart maart 5.7M Sep 17 20:07 app-release-full-optimize.apk
-rwxrwxrwx 1 maart maart  23M Sep 17 20:08 app-release-no-optimize-stuff.apk
-rwxrwxrwx 1 maart maart 5.9M Sep 17 20:13 app-release-old-processing.apk
-rwxrwxrwx 1 maart maart 7.5M Sep 17 20:25 app-release-r8-standard.apk
```

Full optimize with r8 , gives the smallest apk but destroys stracktrace debug information. This info is crucial.

(enabled with)
```
            isMinifyEnabled = true
            isShrinkResources = true

            proguardFiles(
                getDefaultProguardFile("proguard-android-optimize.txt"),
                "proguard-rules.pro"
            )
```

see 

<img width="622" height="1225" alt="image" src="https://github.com/user-attachments/assets/411ae572-aef2-4e1f-98b8-d11c8cea111b" />

So I have restored the deprecated postprocessing block, it creates the second smallest APK but still retains enough to preserve useful stacktraces. I read about it, apparently it creates some kind of custom proguard rules.

I don't know why postprocessing was deprecated but when we upgrade to AGP 9, we will have to look into recreating those proguard rules.

Also those baselines profile warnings are gone now.