### PR TITLE
Reduce recompositions in the comments

### DIFF
--- a/app/src/main/java/com/jerboa/JerboaAppState.kt
+++ b/app/src/main/java/com/jerboa/JerboaAppState.kt
@@ -1,6 +1,7 @@
 package com.jerboa
 
 import android.os.Parcelable
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -187,11 +188,13 @@ class JerboaAppState(
         navController.navigate(Route.COMMUNITY_SIDEBAR)
     }
 
+    @Stable
     fun toProfile(
         id: PersonId,
-        saved: Boolean = false,
+//        saved: Boolean = false,
     ) {
-        navController.navigate(Route.ProfileFromIdArgs.makeRoute(id = "$id", saved = "$saved"))
+        Log.i("JerboaAppState", "toProfile: $id")
+        navController.navigate(Route.ProfileFromIdArgs.makeRoute(id = "$id", saved = "${false}"))
     }
 
     fun toPostLikes(postId: PostId) {

--- a/app/src/main/java/com/jerboa/JerboaAppState.kt
+++ b/app/src/main/java/com/jerboa/JerboaAppState.kt
@@ -188,13 +188,11 @@ class JerboaAppState(
         navController.navigate(Route.COMMUNITY_SIDEBAR)
     }
 
-    @Stable
     fun toProfile(
         id: PersonId,
-//        saved: Boolean = false,
+        saved: Boolean = false,
     ) {
-        Log.i("JerboaAppState", "toProfile: $id")
-        navController.navigate(Route.ProfileFromIdArgs.makeRoute(id = "$id", saved = "${false}"))
+        navController.navigate(Route.ProfileFromIdArgs.makeRoute(id = "$id", saved = "$saved"))
     }
 
     fun toPostLikes(postId: PostId) {

--- a/app/src/main/java/com/jerboa/model/PostViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/PostViewModel.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -74,6 +75,7 @@ class PostViewModel(
 
     val unExpandedComments = mutableStateListOf<CommentId>()
     val commentsWithToggledActionBar = mutableStateListOf<CommentId>()
+    val parentListStateIndexes = mutableListOf<Int>()
 
     init {
         this.getData()
@@ -82,6 +84,28 @@ class PostViewModel(
     fun updateSortType(sortType: CommentSortType) {
         this.sortType = sortType
     }
+
+    fun toggleExpanded(commentId: CommentId) {
+        if (unExpandedComments.contains(commentId)) {
+            unExpandedComments.remove(commentId)
+        } else {
+            unExpandedComments.add(commentId)
+        }
+    }
+
+    fun isExpanded(commentId: CommentId): Boolean = !unExpandedComments.contains(commentId)
+
+    fun toggleExpanded(commentView: CommentView) = toggleExpanded(commentView.comment.id)
+
+    fun toggleActionBar(commentId: CommentId) {
+        if (commentsWithToggledActionBar.contains(commentId)) {
+            commentsWithToggledActionBar.remove(commentId)
+        } else {
+            commentsWithToggledActionBar.add(commentId)
+        }
+    }
+
+    fun toggleActionBar(commentView: CommentView) = toggleActionBar(commentView.comment.id)
 
     fun getData(state: ApiState<GetPostResponse> = ApiState.Loading) {
         val postForm =
@@ -274,6 +298,7 @@ class PostViewModel(
                     updatePostHidden(form.hide)
                     Toast.makeText(ctx, msg, Toast.LENGTH_SHORT).show()
                 }
+
                 else -> {}
             }
         }
@@ -387,6 +412,7 @@ class PostViewModel(
                 val newRes = ApiState.Success(data.copy(post_view = newPostView))
                 postRes = newRes
             }
+
             else -> {}
         }
 
@@ -397,6 +423,7 @@ class PostViewModel(
                 val newRes = ApiState.Success(existing.data.copy(comments = comments))
                 commentsRes = newRes
             }
+
             else -> {}
         }
     }
@@ -415,6 +442,7 @@ class PostViewModel(
                 val newRes = ApiState.Success(data.copy(post_view = newPostView))
                 postRes = newRes
             }
+
             else -> {}
         }
 
@@ -425,6 +453,7 @@ class PostViewModel(
                 val newRes = ApiState.Success(existing.data.copy(comments = comments))
                 commentsRes = newRes
             }
+
             else -> {}
         }
     }


### PR DESCRIPTION

Well I have reduced the recompositions in the comments, it no longer recomposes while it scrolls.

Cause was the topbar, the padding constantly changes, by moving the body into a separate composable I create a new "root" composable, This composable skips recompositions due to its params never changing. Before it everytime it would recreate everything below when the padding changed. It would recreate the commentsTreeList, the lambda, ... bc of that those comments all had changed params. and thus the whole tree down recomposed.

As you can see from the video when you do any action though, it fully recomposes the entire comments. To achieve only the vote itself recomposing, it would need to refactored to use something similar like we did for the postfeed. But thats too much work for now. Cuz currently it creates a new list each time an actions happens upon the comments. Thus they arent equal anymore.

Sadly this did not end up fixing #1711

So there is still something else going on that makes those images pop in and pop out constantly.


before (whole tree recomposes on every scroll)

https://github.com/user-attachments/assets/eac78dd6-5e5a-47ed-8a28-c1eba8392928

after (only the pulldownrefresh recomposes because padding changes, and mainbody skips every recompose)


https://github.com/user-attachments/assets/3b6d2058-5f92-464e-b407-831862498e71


 