### PR TITLE
Implement view pooling for AndroidViews

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
@@ -203,11 +203,10 @@ object MarkdownHelper {
         )
     }
 
-    private fun createTextView(context: Context): TextView {
-        return TextView(context).apply {
+    private fun createTextView(context: Context): TextView =
+        TextView(context).apply {
             width = maxWidth
         }
-    }
 
     private fun applyTextStyle(
         textView: TextView,
@@ -281,8 +280,8 @@ object MarkdownHelper {
     private fun createTextViewPreview(
         context: Context,
         maxLines: Int = 5,
-    ): TextView {
-        return TextView(context).apply {
+    ): TextView =
+        TextView(context).apply {
             width = maxWidth
             layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
             this.movementMethod = null
@@ -291,7 +290,6 @@ object MarkdownHelper {
             setMaxLines(maxLines)
             focusable = NOT_FOCUSABLE
         }
-    }
 
     private fun applyTextStylePreview(
         textView: TextView,
@@ -316,4 +314,3 @@ object MarkdownHelper {
         }
     }
 }
-

--- a/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
@@ -173,16 +173,20 @@ object MarkdownHelper {
         style: TextStyle = MaterialTheme.typography.bodyLarge,
     ) {
         AndroidView(
-            factory = { ctx ->
-                createTextView(
-                    context = ctx,
+            factory = { ctx -> createTextView(context = ctx) },
+            update = { textView ->
+                applyTextStyle(
+                    textView = textView,
                     color = color,
                     style = style,
-                    onClick = onClick,
-                    onLongClick = onLongClick,
                 )
-            },
-            update = { textView ->
+                // Set on every recomposition (not just in `factory`), since with onReset
+                // the underlying View may be pooled/reused for a different item. If we only
+                // set these in `factory`, a reused View would keep firing the click handlers
+                // of the item it was originally created for.
+                textView.setOnClickListener(onClick?.let { click -> View.OnClickListener { click() } })
+                textView.setOnLongClickListener(onLongClick)
+
                 val parser = markwon!!
                 val md = parser.toMarkdown(markdown)
                 for (img in md.getSpans(0, md.length, AsyncDrawableSpan::class.java)) {
@@ -190,19 +194,29 @@ object MarkdownHelper {
                 }
                 parser.setParsedMarkdown(textView, md)
             },
+            onReset = { textView ->
+                textView.setOnClickListener(null)
+                textView.setOnLongClickListener(null)
+                textView.text = null
+            },
             modifier = modifier,
         )
     }
 
-    private fun createTextView(
-        context: Context,
-        color: Color = Color.Unspecified,
+    private fun createTextView(context: Context): TextView {
+        return TextView(context).apply {
+            width = maxWidth
+        }
+    }
+
+    private fun applyTextStyle(
+        textView: TextView,
+        color: Color,
         textAlign: TextAlign? = null,
         @FontRes fontResource: Int? = null,
         style: TextStyle,
-        onClick: (() -> Unit)? = null,
-        onLongClick: ((View) -> Boolean)? = null,
-    ): TextView {
+    ) {
+        val context = textView.context
         val textColor = color.takeOrElse { style.color }
         val mergedStyle =
             style.merge(
@@ -212,15 +226,12 @@ object MarkdownHelper {
                     textAlign = textAlign ?: TextAlign.Unspecified,
                 ),
             )
-        return TextView(context).apply {
-            onClick?.let { setOnClickListener { onClick() } }
-            onLongClick?.let { setOnLongClickListener(it) }
+        textView.apply {
             setTextColor(textColor.toArgb())
             setTextSize(TypedValue.COMPLEX_UNIT_SP, mergedStyle.fontSize.value)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 lineHeight = convertSpToPx(mergedStyle.lineHeight, context)
             }
-            width = maxWidth
 
             textAlign?.let { align ->
                 textAlignment =
@@ -232,9 +243,7 @@ object MarkdownHelper {
                     }
             }
 
-            fontResource?.let { font ->
-                typeface = ResourcesCompat.getFont(context, font)
-            }
+            typeface = fontResource?.let { font -> ResourcesCompat.getFont(context, font) }
         }
     }
 
@@ -247,16 +256,23 @@ object MarkdownHelper {
         style: TextStyle,
     ) {
         AndroidView(
-            factory = { ctx ->
-                createTextViewPreview(
-                    context = ctx,
+            factory = { ctx -> createTextViewPreview(context = ctx) },
+            update = { textView ->
+                applyTextStylePreview(
+                    textView = textView,
                     color = color,
                     style = style,
-                    onClick = onClick,
                 )
-            },
-            update = { textView ->
+                // Set on every recomposition (not just in `factory`), since with onReset
+                // the underlying View may be pooled/reused for a different item. If we only
+                // set this in `factory`, a reused View would keep firing the click handler
+                // of the item it was originally created for (e.g. opening the wrong post).
+                textView.setOnClickListener(onClick?.let { click -> View.OnClickListener { click() } })
                 previewMarkwon?.setMarkdown(textView, markdown)
+            },
+            onReset = { textView ->
+                textView.setOnClickListener(null)
+                textView.text = null
             },
             modifier = modifier,
         )
@@ -264,26 +280,9 @@ object MarkdownHelper {
 
     private fun createTextViewPreview(
         context: Context,
-        color: Color = Color.Unspecified,
         maxLines: Int = 5,
-        style: TextStyle,
-        onClick: (() -> Unit)? = null,
     ): TextView {
-        val textColor = color.takeOrElse { style.color }
-        val mergedStyle =
-            style.merge(
-                TextStyle(
-                    color = textColor,
-                    fontSize = style.fontSize,
-                ),
-            )
         return TextView(context).apply {
-            onClick?.let { setOnClickListener { onClick() } }
-            setTextColor(textColor.toArgb())
-            setTextSize(TypedValue.COMPLEX_UNIT_SP, mergedStyle.fontSize.value)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                lineHeight = convertSpToPx(mergedStyle.lineHeight, context)
-            }
             width = maxWidth
             layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
             this.movementMethod = null
@@ -293,4 +292,28 @@ object MarkdownHelper {
             focusable = NOT_FOCUSABLE
         }
     }
+
+    private fun applyTextStylePreview(
+        textView: TextView,
+        color: Color,
+        style: TextStyle,
+    ) {
+        val context = textView.context
+        val textColor = color.takeOrElse { style.color }
+        val mergedStyle =
+            style.merge(
+                TextStyle(
+                    color = textColor,
+                    fontSize = style.fontSize,
+                ),
+            )
+        textView.apply {
+            setTextColor(textColor.toArgb())
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, mergedStyle.fontSize.value)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                lineHeight = convertSpToPx(mergedStyle.lineHeight, context)
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
By adding the onReset we allow the AndroidView to be pooled by lazycolumns. 

We have to be careful with this though. Has been tried before but caused subtle bugs as it would hold stale references such as clickhandlers. As they werent being updated in the onUpdate.

Everything is moved to Update now instead of factory which is only set once. Not sure how much it benefits from this as each reuse still causes markwon to parse and set the text. (which is prob more expensive than the view). 

I have only briefly tested this. but if merged, you cant release this immediately it needs long release build testing. to be sure there are no subtle bugs intrduced by this. (it shouldnt but not impossible)

Btw this also fixes #1711 but cause weird jumping behaviour in the feed. Its really obvious now that the image loads in later. But its no longer stuck :)

So both PRs are required for smooth scroll allthough havent tested with both at the same time
