### PR TITLE
Remove duplicate translation key

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -203,7 +203,7 @@ fun CommunityHeader(
                 }) {
                     Icon(
                         Icons.AutoMirrored.Outlined.Sort,
-                        contentDescription = stringResource(R.string.community_sortBy),
+                        contentDescription = stringResource(R.string.selectSort),
                     )
                 }
 

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
@@ -211,7 +211,7 @@ fun PersonProfileHeader(
                 }) {
                     Icon(
                         Icons.AutoMirrored.Outlined.Sort,
-                        contentDescription = stringResource(R.string.community_sortBy),
+                        contentDescription = stringResource(R.string.selectSort),
                     )
                 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -74,7 +74,6 @@
     <string name="community_link_users_month">%1$s مستخدمين بالشهر</string>
     <string name="community_list_search">ابحث…</string>
     <string name="community_pending">انتظر الإذن</string>
-    <string name="community_sortBy">رتِّب حسب</string>
     <string name="community_subscribe">اشترك</string>
     <string name="community_users_month">%1$s مستخدمين بالشهر</string>
     <string name="crash_logs">سجلَّات التعطُّل</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -74,7 +74,6 @@
     <string name="community_link_users_month">%1$s istifadəçi / ay</string>
     <string name="community_list_search">Axtar…</string>
     <string name="community_pending">Gözlə</string>
-    <string name="community_sortBy">Çeşidlə</string>
     <string name="community_subscribe">Abunə ol</string>
     <string name="community_users_month">%1$s istifadəçi / ay</string>
     <string name="crash_logs">Çökmə Jurnalları</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -76,7 +76,6 @@
     <string name="community_link_users_month">%1$s потребители / месец</string>
     <string name="community_list_search">Търсене…</string>
     <string name="community_pending">В очакване</string>
-    <string name="community_sortBy">Подреждане по</string>
     <string name="community_subscribe">Абониране</string>
     <string name="community_users_month">%1$s потребители / месец</string>
     <string name="crash_logs">Дневник на сривовете</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -72,7 +72,6 @@
     <string name="community_link_users_month">%1$s korisnika / mjesec</string>
     <string name="community_list_search">Pretraži…</string>
     <string name="community_pending">Na čekanju</string>
-    <string name="community_sortBy">Sortiraj</string>
     <string name="community_subscribe">Pretplati se</string>
     <string name="crash_logs">Dnevnici grešaka</string>
     <string name="crash_logs_all_deleted">Svi dnevnici grešaka su obrisani</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -166,7 +166,6 @@
     <string name="dialog_moreOptions">Vis flere muligheder</string>
     <string name="comment_edit_save">Gem redigeret kommentar</string>
     <string name="commentReply_send">Send svar</string>
-    <string name="community_sortBy">Sorter efter</string>
     <string name="floating_createPost">Opret indlæg</string>
     <string name="community_icon">Fællesskabets ikon</string>
     <string name="form_submit">Indsend</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -174,7 +174,6 @@
     <string name="dialog_moreOptions">Zeige mehr Optionen</string>
     <string name="comment_edit_save">Kommentarbearbeitung speichern</string>
     <string name="commentReply_send">Antwort senden</string>
-    <string name="community_sortBy">Sortieren nach</string>
     <string name="floating_createPost">Beitrag erstellen</string>
     <string name="community_icon">Community Symbol</string>
     <string name="form_submit">Abschicken</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -74,7 +74,6 @@
     <string name="community_link_users_month">%1$s χρήστες / μήνα</string>
     <string name="community_list_search">Αναζήτηση…</string>
     <string name="community_pending">Εκκρεμεί</string>
-    <string name="community_sortBy">Ταξινόμηση κατά</string>
     <string name="community_subscribe">Εγγραφή</string>
     <string name="community_users_month">%1$s χρήστες / μήνα</string>
     <string name="createPost_selectCommunity">Επιλογή κοινότητας από τη λίστα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -184,7 +184,6 @@
     <string name="dialog_moreOptions">Mostrar más opciones</string>
     <string name="comment_edit_save">Guardar ediciones del comentario</string>
     <string name="commentReply_send">Enviar respuesta</string>
-    <string name="community_sortBy">Ordenar por</string>
     <string name="dialogs_server_version_outdated">La versión del servidor (%1$s) se encuentra por debajo de la versión mínima soportada (%2$s).</string>
     <string name="dialogs_server_version_outdated_short">La versión del servidor (%1$s) es muy baja.</string>
     <string name="floating_createPost">Crear post</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -182,7 +182,6 @@
     <string name="dialog_moreOptions">Plus d’options</string>
     <string name="comment_edit_save">Enregistrer les modifications</string>
     <string name="commentReply_send">Envoyer la réponse</string>
-    <string name="community_sortBy">Trier par</string>
     <string name="dialogs_server_version_outdated">La version du serveur (%1$s) est inférieure à la version minimale prise en charge (%2$s). Veuillez informer l’administrateur de l’instance et vous connecter à une autre instance, ou vous déconnecter et utiliser l’instance par défaut.</string>
     <string name="floating_createPost">Créer publication</string>
     <string name="community_icon">Icône de la communauté</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -59,7 +59,6 @@
     <string name="community_joined">Csatlakozva</string>
     <string name="community_list_search">Keresés…</string>
     <string name="community_pending">Folyamatban</string>
-    <string name="community_sortBy">Rendezési elv</string>
     <string name="community_subscribe">Feliratkozás</string>
     <string name="community_users_month">%1$s felhasználó / hónap</string>
     <string name="crash_logs">Hibanapló</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -74,7 +74,6 @@
     <string name="community_link_users_month">%1$s utenti / mese</string>
     <string name="community_list_search">Cerca…</string>
     <string name="community_pending">In attesa</string>
-    <string name="community_sortBy">Ordina per</string>
     <string name="community_subscribe">Partecipa</string>
     <string name="community_users_month">%1$s utenti / mese</string>
     <string name="createPost_selectCommunity">Seleziona comunità dalla lista</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -167,7 +167,6 @@
     <string name="dialog_moreOptions">追加オプションを表示</string>
     <string name="comment_edit_save">コメント編集を保存</string>
     <string name="commentReply_send">返信を送る</string>
-    <string name="community_sortBy">並び替え</string>
     <string name="floating_createPost">投稿を作成</string>
     <string name="community_icon">コミュニティアイコン</string>
     <string name="form_submit">確定</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -74,7 +74,6 @@
     <string name="community_link_users_month">%1$s 사용자 / 월</string>
     <string name="community_list_search">검색…</string>
     <string name="community_pending">보류 중</string>
-    <string name="community_sortBy">정렬</string>
     <string name="community_subscribe">구독</string>
     <string name="community_users_month">%1$s 사용자 / 월</string>
     <string name="crash_logs">크래시 기록</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -49,7 +49,6 @@
     <string name="community_community_info">Kopienas informācija</string>
     <string name="community_icon">Kopienas ikona</string>
     <string name="community_users_month">%1$s lietotāji / mēnesī</string>
-    <string name="community_sortBy">Kārtot pēc</string>
     <string name="home_site_info">Vietnes informācija</string>
     <string name="home_subscribed">Abonementi</string>
     <string name="home_subscriptions">Abonementi</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -62,7 +62,6 @@
     <string name="community_users_month">%1$s gebruikers / maand</string>
     <string name="community_icon">Community icoon</string>
     <string name="community_joined">Lid geworden</string>
-    <string name="community_sortBy">Sorteer op</string>
     <string name="community_subscribe">Abonneren</string>
     <string name="community_pending">In behandeling</string>
     <string name="comment_save">Bewaar reactie</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -76,7 +76,6 @@
     <string name="community_link_users_month">%1$s brukarar/månad</string>
     <string name="community_list_search">Søk …</string>
     <string name="community_pending">Ventar</string>
-    <string name="community_sortBy">Sorter etter</string>
     <string name="community_subscribe">Abonner</string>
     <string name="community_users_month">%1$s brukarar/månad</string>
     <string name="crash_logs">Krasjloggar</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -167,7 +167,6 @@
     <string name="dialog_moreOptions">Pokaż więcej opcji</string>
     <string name="comment_edit_save">Zapisz edytowany komentarz</string>
     <string name="commentReply_send">Wyślij odpowiedź</string>
-    <string name="community_sortBy">Sortuj po</string>
     <string name="floating_createPost">Stwórz post</string>
     <string name="community_icon">Ikonka Społeczności</string>
     <string name="form_submit">Prześlij</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -22,7 +22,6 @@
     <string name="community_link_users_month">%1$s пользователей / месяц</string>
     <string name="community_list_search">Поиск…</string>
     <string name="community_pending">В ожидании</string>
-    <string name="community_sortBy">Отсортировать по</string>
     <string name="community_subscribe">Подписаться</string>
     <string name="community_users_month">%1$s пользователей / месяц</string>
     <string name="crash_logs">Журналы сбоев</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -166,7 +166,6 @@
     <string name="dialog_moreOptions">Visa fler alternativ</string>
     <string name="comment_edit_save">Spara redigerad kommentar</string>
     <string name="commentReply_send">Skicka svar</string>
-    <string name="community_sortBy">Sortera efter</string>
     <string name="floating_createPost">Skapa inlägg</string>
     <string name="community_icon">Gemenskapens profilbild</string>
     <string name="form_submit">Skicka in</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -76,7 +76,6 @@
     <string name="community_link_users_month">%1$s kullanıcı / ay</string>
     <string name="community_list_search">Ara…</string>
     <string name="community_pending">Beklemede</string>
-    <string name="community_sortBy">Sırala</string>
     <string name="community_subscribe">Abone ol</string>
     <string name="community_users_month">%1$s kullanıcı / ay</string>
     <string name="crash_logs">Hata günlükleri</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -74,7 +74,6 @@
     <string name="community_link_users_month">%1$s користувачів за місяць</string>
     <string name="community_list_search">Що ви шукаєте?</string>
     <string name="community_pending">Очікує на розгляд</string>
-    <string name="community_sortBy">Впорядкувати за</string>
     <string name="community_subscribe">Підписатися</string>
     <string name="community_users_month">%1$s користувачів за місяць</string>
     <string name="createPost_selectCommunity">Обрати спільноту з переліку</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -76,7 +76,6 @@
     <string name="community_link_users_month">%1$s 月用户数</string>
     <string name="community_list_search">搜索…</string>
     <string name="community_pending">待处理</string>
-    <string name="community_sortBy">排序方式</string>
     <string name="community_subscribe">订阅</string>
     <string name="community_users_month">%1$s 月用户数</string>
     <string name="crash_logs">崩溃日志</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,6 @@
     <string name="community_link_users_month">%1$s users / month</string>
     <string name="community_list_search">Search…</string>
     <string name="community_pending">Pending</string>
-    <string name="community_sortBy">Sort by</string>
     <string name="community_subscribe">Subscribe</string>
     <string name="community_users_month">%1$s users / month</string>
     <string name="crash_logs">Crash logs</string>


### PR DESCRIPTION
That was the last change that hadn't been extracted from the draft PR.

Its a duplicate translation that was only used by contentDescription.