### PR TITLE
Fix android lint

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -267,6 +267,6 @@
     <string name="share_post">Beitrag teilen</string>
     <string name="unlock_post">Beitrag entsperren</string>
     <string name="lock_post">Beitrag sperren</string>
-    <string name="show_upvote_percentage">Upvoteverhältnis in %% anzeigen</string>
+    <string name="show_upvote_percentage" formatted="false">Upvoteverhältnis in % anzeigen</string>
     <string name="remove_post">Beitrag entfernen</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -267,5 +267,5 @@
     <string name="hide_post">Cacher la publication</string>
     <string name="show_downvotes">Afficher les votes contre</string>
     <string name="remove_content">Supprimer le contenu</string>
-    <string name="show_upvote_percentage">Afficher le % de votes pour</string>
+    <string name="show_upvote_percentage" formatted="false">Afficher le % de votes pour</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -435,7 +435,7 @@
     <string name="post_hidden">Rejtett bejegyzés</string>
     <string name="hide_post">Bejegyzés rejtése</string>
     <string name="show_downvotes">Lepontozások mutatása</string>
-    <string name="show_upvote_percentage">Felpontozás % mutatása</string>
+    <string name="show_upvote_percentage" formatted="false">Felpontozás % mutatása</string>
     <string name="score">Pontszám</string>
     <string name="info">Infó</string>
     <string name="settings_about_baseline_profile">Baseline profil</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -466,7 +466,7 @@
     <string name="unhide_post">Fjern gøyming av innlegg</string>
     <string name="show_upvotes">Vis opprøyster</string>
     <string name="show_downvotes">Vis nedrøyster</string>
-    <string name="show_upvote_percentage">Vis opprøystings-%</string>
+    <string name="show_upvote_percentage" formatted="false">Vis opprøystings-%</string>
     <string name="score">Poeng</string>
     <string name="info">Info</string>
     <string name="settings_about_baseline_profile">Baseline-profil</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -173,7 +173,7 @@
     <string name="loading">Carregando</string>
     <string name="save">Salvar</string>
     <string name="remove_content">Apagar conteúdo</string>
-    <string name="show_upvote_percentage">Mostrar % de votos positivos</string>
+    <string name="show_upvote_percentage" formatted="false">Mostrar % de votos positivos</string>
     <string name="show_upvotes">Mostrar votos positivos</string>
     <string name="remove_comment">Apagar comentário</string>
     <string name="reports">Denúncias</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -467,7 +467,7 @@
     <string name="unhide_post">Gönderiyi gizleme</string>
     <string name="show_upvotes">Yukarı oyları göster</string>
     <string name="show_downvotes">Aşağı oyları göster</string>
-    <string name="show_upvote_percentage">Yukarı oy % göster</string>
+    <string name="show_upvote_percentage" formatted="false">Yukarı oy % göster</string>
     <string name="score">Puan</string>
     <string name="info">Bilgi</string>
     <string name="settings_about_baseline_profile">Temel profil</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -453,7 +453,7 @@
     <string name="unhide_post">取消隐藏帖子</string>
     <string name="show_upvotes">显示顶数</string>
     <string name="show_downvotes">显示踩数</string>
-    <string name="show_upvote_percentage">显示顶数百分比%</string>
+    <string name="show_upvote_percentage" formatted="false">显示顶数百分比%</string>
     <string name="score">分数</string>
     <string name="info">信息</string>
     <string name="settings_about_baseline_profile">基线配置文件</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,7 +475,7 @@
     <string name="unhide_post">Unhide post</string>
     <string name="show_upvotes">Show upvotes</string>
     <string name="show_downvotes">Show downvotes</string>
-    <string name="show_upvote_percentage">Show upvote %</string>
+    <string name="show_upvote_percentage" formatted="false">Show upvote %</string>
     <string name="score">Score</string>
     <string name="info">Info</string>
     <string name="settings_about_baseline_profile">Baseline profile</string>


### PR DESCRIPTION
The lint was falen on the unescaped `%`

```
  /woodpecker/src/github.com/LemmyNet/jerboa/app/src/main/res/values-tr/strings.xml:470: Error: Incorrect formatting string show_upvote_percentage; missing conversion character in '% g'? [StringFormatInvalid]
      <string name="show_upvote_percentage">Yukarı oy % göster</string>
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
     Explanation for issues of type "StringFormatInvalid":
     If a string contains a '%' character, then the string may be a formatting
     string which will be passed to String.format from Java code to replace each
     '%' occurrence with specific values.
  
     This lint warning checks for two related problems:
     (1) Formatting strings that are invalid, meaning that String.format will
     throw exceptions at runtime when attempting to use the format string.
     (2) Strings containing '%' that are not formatting strings getting passed
     to a String.format call. In this case the '%' will need to be escaped as
     '%%'.
  
     NOTE: Not all Strings which look like formatting strings are intended for
     use by String.format; for example, they may contain date formats intended
     for android.text.format.Time#format(). Lint cannot always figure out that a
     String is a date format, so you may get false warnings in those scenarios.
     See the suppress help topic for information on how to suppress errors in
     that case.
 ```
 
 But it wasnt necessary to escape this, if you put it double it appears double. Instead you have to mark it as not formatted and then the lints stops complaining.